### PR TITLE
Use MySQL 8.0 from Docker

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eu
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+docker-compose up -d --remove-orphans
+docker-compose ps
+
+bundle
+
+echo "Creating databases..."
+
+rails db:setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.8"
+
+volumes:
+  db: {}
+
+services:
+  mysql:
+    image: mysql:8.0.31
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    volumes:
+      - db:/var/lib/mysql
+    ports: [ "127.0.0.1:33060:3306" ]

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -10,7 +10,7 @@ default: &default
   username: root
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: "127.0.0.1"
-  port: 3306
+  port: 33060
 
 development:
   <<: *default


### PR DESCRIPTION
So it doesn't interfere with local MySQL 5.7 used in most of our apps, as the DBs and the options aren't compatible.

This is mostly taken from @djmb's [setup for solid_cache](https://github.com/basecamp/solid_cache/blob/main/docker-compose.yml) 🙇‍♀️  