### PR TITLE
Store Active Job's Job ID in SolidJob in a query-able way

### DIFF
--- a/app/models/solid_queue/job.rb
+++ b/app/models/solid_queue/job.rb
@@ -7,6 +7,7 @@ class SolidQueue::Job < ActiveRecord::Base
     def enqueue_active_job(active_job, scheduled_at: Time.current)
       enqueue \
         queue_name: active_job.queue_name,
+        active_job_id: active_job.job_id,
         priority: active_job.priority,
         scheduled_at: scheduled_at,
         arguments: active_job.serialize

--- a/db/migrate/20230207182223_create_solid_queue_tables.rb
+++ b/db/migrate/20230207182223_create_solid_queue_tables.rb
@@ -4,12 +4,16 @@ class CreateSolidQueueTables < ActiveRecord::Migration[7.0]
       t.string :queue_name, null: false
       t.text :arguments
 
+      t.string :active_job_id
+
       t.integer :priority, default: 0, null: false
 
       t.datetime :scheduled_at
       t.datetime :finished_at
 
       t.timestamps
+
+      t.index :active_job_id, name: "index_solid_queue_jobs_on_job_id"
     end
 
     create_table :solid_queue_scheduled_executions do |t|

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -28,11 +28,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_07_182223) do
   create_table "solid_queue_jobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "queue_name", null: false
     t.text "arguments"
+    t.string "active_job_id"
     t.integer "priority", default: 0, null: false
     t.datetime "scheduled_at"
     t.datetime "finished_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_job_id"
   end
 
   create_table "solid_queue_ready_executions", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|


### PR DESCRIPTION
For now, for reporting and debugging purposes. Maybe we don't need it in the end, so I'll remove it if that's the case. 