### PR TITLE
Allow running scheduler and dispatchers separately

### DIFF
--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -23,10 +23,6 @@ class SolidQueue::Configuration
     end.deep_symbolize_keys
   end
 
-  def scheduler_disabled?
-    raw_config.dig(:scheduler, :disabled)
-  end
-
   def scheduler_options
     (raw_config[:scheduler] || {}).with_defaults(SCHEDULER_DEFAULTS)
   end

--- a/lib/solid_queue/tasks.rb
+++ b/lib/solid_queue/tasks.rb
@@ -1,6 +1,11 @@
 namespace :solid_queue do
-  desc "start solid_queue supervisor"
-  task start: :environment do
-    SolidQueue::Supervisor.start
+  desc "start solid_queue supervisor to process jobs"
+  task work: :environment do
+    SolidQueue::Supervisor.start(mode: :work)
+  end
+
+  desc "start solid_queue scheduler to enqueue scheduled jobs"
+  task schedule: :environment do
+    SolidQueue::Supervisor.start(mode: :schedule)
   end
 end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -4,7 +4,6 @@ class ConfigurationTest < ActiveSupport::TestCase
   test "read configuration from default file" do
     configuration = SolidQueue::Configuration.new
     assert 2, configuration.queues.count
-    assert_not configuration.scheduler_disabled?
     assert_not_empty configuration.scheduler_options
   end
 


### PR DESCRIPTION
We'd want to run one instance of the scheduler in one special pod and dispatchers in many job pods. The previous way of doing this, by having different configurations disabling the scheduler, was very cumbersome. 