### PR TITLE
Allow configuring process heartbeat interval and alive threshold

### DIFF
--- a/app/models/solid_queue/process.rb
+++ b/app/models/solid_queue/process.rb
@@ -1,9 +1,6 @@
 class SolidQueue::Process < ActiveRecord::Base
   include Prunable
 
-  HEARTBEAT_INTERVAL = 60.seconds
-  ALIVE_THRESHOLD = HEARTBEAT_INTERVAL * 5
-
   serialize :metadata, JSON
 
   has_many :claimed_executions

--- a/app/models/solid_queue/process/prunable.rb
+++ b/app/models/solid_queue/process/prunable.rb
@@ -2,7 +2,7 @@ module SolidQueue::Process::Prunable
   extend ActiveSupport::Concern
 
   included do
-    scope :prunable, -> { where("last_heartbeat_at <= ?", SolidQueue::Process::ALIVE_THRESHOLD.ago) }
+    scope :prunable, -> { where("last_heartbeat_at <= ?", SolidQueue.process_alive_threshold.ago) }
   end
 
   class_methods do

--- a/lib/solid_queue.rb
+++ b/lib/solid_queue.rb
@@ -14,4 +14,7 @@ require "solid_queue/supervisor"
 module SolidQueue
   mattr_accessor :logger, default: ActiveSupport::Logger.new($stdout)
   mattr_accessor :app_executor
+
+  mattr_accessor :process_heartbeat_interval, default: 60.seconds
+  mattr_accessor :process_alive_threshold, default: 5.minutes
 end

--- a/lib/solid_queue/engine.rb
+++ b/lib/solid_queue/engine.rb
@@ -8,7 +8,14 @@ module SolidQueue
 
     config.solid_queue = ActiveSupport::OrderedOptions.new
 
-    initializer "solid_queue.config", before: :run_prepare_callbacks do |app|
+    initializer "solid_queue.config" do
+      config.after_initialize do |app|
+        SolidQueue.process_heartbeat_interval = app.config.solid_queue.process_heartbeat_interval || 60.seconds
+        SolidQueue.process_alive_threshold    = app.config.solid_queue.process_alive_threshold || 5.minutes
+      end
+    end
+
+    initializer "solid_queue.app_executor", before: :run_prepare_callbacks do |app|
       config.solid_queue.app_executor ||= app.executor
 
       SolidQueue.app_executor = config.solid_queue.app_executor

--- a/lib/solid_queue/runner/process_registration.rb
+++ b/lib/solid_queue/runner/process_registration.rb
@@ -32,7 +32,7 @@ module SolidQueue::Runner::ProcessRegistration
     end
 
     def start_heartbeat
-      @heartbeat_task = Concurrent::TimerTask.new(execution_interval: SolidQueue::Process::HEARTBEAT_INTERVAL) { heartbeat }
+      @heartbeat_task = Concurrent::TimerTask.new(execution_interval: SolidQueue.process_heartbeat_interval) { heartbeat }
       @heartbeat_task.execute
     end
 

--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -61,7 +61,7 @@ class SolidQueue::Supervisor
     end
 
     def start_process_prune
-      @prune_task = Concurrent::TimerTask.new(run_now: true, execution_interval: SolidQueue::Process::ALIVE_THRESHOLD) { prune_dead_processes }
+      @prune_task = Concurrent::TimerTask.new(run_now: true, execution_interval: SolidQueue.process_alive_threshold) { prune_dead_processes }
       @prune_task.execute
     end
 


### PR DESCRIPTION
For now, they're global and apply to all processes, but we could make them per process so that each dispatcher and the scheduler have different thresholds. 