### PR TITLE
Set sync to true for STDOUT and STDERR when starting supervisor

### DIFF
--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -20,6 +20,7 @@ module SolidQueue
     def start
       procline "starting"
 
+      sync_std_streams
       setup_pidfile
       register_signal_handlers
       start_process_prune
@@ -41,6 +42,10 @@ module SolidQueue
 
     private
       attr_reader :runners, :forks
+
+      def sync_std_streams
+        STDOUT.sync = STDERR.sync = true
+      end
 
       def setup_pidfile
         @pidfile = if SolidQueue.supervisor_pidfile


### PR DESCRIPTION
Otherwise log to `STDOUT` and `STDERR` won't work when running in Docker where `STDOUT` and `STDERR` are pointing to `/proc/self/fd/1`, and that's passed around in forked processes.