### PR TITLE
Don't add the default queue to the configuration by default

### DIFF
--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -51,8 +51,6 @@ module SolidQueue
       def queues
         @queues ||= (raw_config[:queues] || {}).each_with_object({}) do |(queue_name, options), hsh|
           hsh[queue_name] = options.merge(queue_name: queue_name.to_s).with_defaults(WORKER_DEFAULTS)
-        end.tap do |queues|
-          queues[SolidQueue::Job::DEFAULT_QUEUE_NAME] ||= WORKER_DEFAULTS.merge(queue_name: SolidQueue::Job::DEFAULT_QUEUE_NAME)
         end.deep_symbolize_keys
       end
 

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -14,6 +14,5 @@ class ConfigurationTest < ActiveSupport::TestCase
 
     assert_equal SolidQueue::Configuration::SCHEDULER_DEFAULTS[:polling_interval], configuration.scheduler.polling_interval
     assert configuration.workers.detect { |w| w.queue == "background" }.pool_size > 0
-    assert configuration.workers.any? { |w| w.queue == "default" }
   end
 end


### PR DESCRIPTION
I don't know why I did this, as it'll spawn a worker for a queue that we won't be using in the beginning, doing nothing at all 😅 