### PR TITLE
Don't use Concurrent::FixedThreadPool directly

### DIFF
--- a/lib/solid_queue.rb
+++ b/lib/solid_queue.rb
@@ -9,6 +9,7 @@ require "solid_queue/pidfile"
 require "solid_queue/procline"
 require "solid_queue/signals"
 require "solid_queue/configuration"
+require "solid_queue/pool"
 require "solid_queue/runner"
 require "solid_queue/runner/process_registration"
 require "solid_queue/worker"
@@ -18,6 +19,7 @@ require "solid_queue/supervisor"
 module SolidQueue
   mattr_accessor :logger, default: ActiveSupport::Logger.new($stdout)
   mattr_accessor :app_executor
+  mattr_accessor :on_thread_error
 
   mattr_accessor :process_heartbeat_interval, default: 60.seconds
   mattr_accessor :process_alive_threshold, default: 5.minutes

--- a/lib/solid_queue/app_executor.rb
+++ b/lib/solid_queue/app_executor.rb
@@ -9,5 +9,11 @@ module SolidQueue
         yield
       end
     end
+
+    def handle_thread_error(error)
+      if SolidQueue.on_thread_error
+        SolidQueue.on_thread_error.call(error)
+      end
+    end
   end
 end

--- a/lib/solid_queue/engine.rb
+++ b/lib/solid_queue/engine.rb
@@ -18,9 +18,11 @@ module SolidQueue
     end
 
     initializer "solid_queue.app_executor", before: :run_prepare_callbacks do |app|
-      config.solid_queue.app_executor ||= app.executor
+      config.solid_queue.app_executor    ||= app.executor
+      config.solid_queue.on_thread_error ||= -> (exception) { Rails.error.report(exception) }
 
       SolidQueue.app_executor = config.solid_queue.app_executor
+      SolidQueue.on_thread_error = config.solid_queue.on_thread_error
     end
 
     initializer "solid_queue.logger" do |app|

--- a/lib/solid_queue/pool.rb
+++ b/lib/solid_queue/pool.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module SolidQueue
+  class Pool
+    include AppExecutor
+
+    attr_accessor :size, :executor
+
+    delegate :shutdown, :shutdown?, :wait_for_termination, to: :executor
+
+    def initialize(size)
+      @size = size
+      @executor = Concurrent::FixedThreadPool.new(size)
+    end
+
+    def post(execution, process)
+      future = Concurrent::Future.new(args: [ execution, process ], executor: executor) do |thread_execution, thread_process|
+        wrap_in_app_executor do
+          thread_execution.perform(thread_process)
+        end
+      end
+
+      future.add_observer do |_, _, error|
+        handle_thread_error(error) if error
+      end
+
+      future.execute
+    end
+  end
+end

--- a/lib/solid_queue/worker.rb
+++ b/lib/solid_queue/worker.rb
@@ -1,52 +1,50 @@
 # frozen_string_literal: true
 
-class SolidQueue::Worker
-  include SolidQueue::Runner
+module SolidQueue
+  class Worker
+    include Runner
 
-  attr_accessor :queue, :pool_size, :polling_interval, :pool
+    attr_accessor :queue, :polling_interval, :pool, :pool_size
 
-  def initialize(**options)
-    options = options.dup.with_defaults(SolidQueue::Configuration::WORKER_DEFAULTS)
+    def initialize(**options)
+      options = options.dup.with_defaults(SolidQueue::Configuration::WORKER_DEFAULTS)
 
-    @queue = options[:queue_name].to_s
-    @pool_size = options[:pool_size]
-    @polling_interval = options[:polling_interval]
+      @queue = options[:queue_name].to_s
+      @polling_interval = options[:polling_interval]
 
-    @pool = Concurrent::FixedThreadPool.new(@pool_size)
-  end
+      @pool_size = options[:pool_size]
+      @pool = Pool.new(options[:pool_size])
+    end
 
-  private
-    def run
-      executions = SolidQueue::ReadyExecution.claim(queue, pool_size)
+    private
+      def run
+        claimed_executions = SolidQueue::ReadyExecution.claim(queue, pool_size)
 
-      if executions.size > 0
-        procline "performing #{executions.count} jobs in #{queue}"
+        if claimed_executions.size > 0
+          procline "performing #{claimed_executions.count} jobs in #{queue}"
 
-        executions.each do |execution|
-          pool.post do
-            wrap_in_app_executor do
-              execution.perform(process)
-            end
+          claimed_executions.each do |execution|
+            pool.post(execution, process)
           end
+        else
+          procline "waiting for jobs in #{queue}"
+          interruptible_sleep(polling_interval)
         end
-      else
-        procline "waiting for jobs in #{queue}"
-        interruptible_sleep(polling_interval)
       end
-    end
 
-    def shutdown
-      super
+      def shutdown
+        super
 
-      pool.shutdown
-      pool.wait_for_termination(SolidQueue.shutdown_timeout)
-    end
+        pool.shutdown
+        pool.wait_for_termination(SolidQueue.shutdown_timeout)
+      end
 
-    def shutdown_completed?
-      pool.shutdown?
-    end
+      def shutdown_completed?
+        pool.shutdown?
+      end
 
-    def metadata
-      super.merge(queue: queue, pool_size: pool_size, polling_interval: polling_interval)
-    end
+      def metadata
+        super.merge(queue: queue, pool_size: pool_size, polling_interval: polling_interval)
+      end
+  end
 end


### PR DESCRIPTION
Instead, use a higher-level abstraction (`Future`) where we can add an observer to handle errors in the thread that aren't already handled by the job execution itself.

I learnt about this by reading https://github.com/ruby-concurrency/concurrent-ruby/issues/616 