### PR TITLE
Reduce pauses for faster tests

### DIFF
--- a/test/integration/jobs_lifecycle_test.rb
+++ b/test/integration/jobs_lifecycle_test.rb
@@ -21,7 +21,7 @@ class JobsLifecycleTest < ActiveSupport::TestCase
     @scheduler.start(mode: :async)
     @worker.start(mode: :async)
 
-    wait_for_jobs_to_finish_for(5.seconds)
+    wait_for_jobs_to_finish_for(0.5.seconds)
 
     assert_equal [ "hey", "ho" ], JobBuffer.values.sort
   end
@@ -44,7 +44,7 @@ class JobsLifecycleTest < ActiveSupport::TestCase
 
     travel_to 5.days.from_now
 
-    wait_for_jobs_to_finish_for(5.seconds)
+    wait_for_jobs_to_finish_for(0.5.seconds)
 
     assert_equal 2, JobBuffer.size
     assert_equal "I'm scheduled later", JobBuffer.last_value

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,7 +26,7 @@ class ActiveSupport::TestCase
   end
 
   private
-    def wait_for_jobs_to_finish_for(timeout = 10.seconds)
+    def wait_for_jobs_to_finish_for(timeout = 1.second)
       Timeout.timeout(timeout) do
         while SolidQueue::Job.where(finished_at: nil).any? do
           sleep 0.25
@@ -41,7 +41,7 @@ class ActiveSupport::TestCase
       end
     end
 
-    def wait_for_registered_processes(count, timeout: 10.seconds)
+    def wait_for_registered_processes(count, timeout: 1.second)
       Timeout.timeout(timeout) do
         while SolidQueue::Process.count < count do
           sleep 0.25

--- a/test/unit/worker_test.rb
+++ b/test/unit/worker_test.rb
@@ -37,7 +37,7 @@ class WorkerTest < ActiveSupport::TestCase
 
   test "claim and process more enqueued jobs than the pool size allows to process at once" do
     5.times do |i|
-      StoreResultJob.perform_later(:paused, pause: 1.second)
+      StoreResultJob.perform_later(:paused, pause: 0.1.second)
     end
 
     3.times do |i|


### PR DESCRIPTION
Reduce the pause and wait times so the test complete faster. It was taking about 144 seconds, now it's 48 seconds.

cc @rosa 