### PR TITLE
Add load hooks for SolidQueue::Record

### DIFF
--- a/app/models/solid_queue/record.rb
+++ b/app/models/solid_queue/record.rb
@@ -3,3 +3,5 @@ module SolidQueue
     self.abstract_class = true
   end
 end
+
+ActiveSupport.run_load_hooks :solid_queue_record, SolidQueue::Record

--- a/test/dummy/config/initializers/solid_queue_record.rb
+++ b/test/dummy/config/initializers/solid_queue_record.rb
@@ -1,0 +1,6 @@
+Rails.application.config.x.solid_queue_record_hook_ran = false
+
+ActiveSupport.on_load(:solid_queue_record) do
+  raise "Expected to run on SolidQueue::Record, got #{self.inspect}" unless self == SolidQueue::Record
+  Rails.application.config.x.solid_queue_record_hook_ran = true
+end

--- a/test/unit/hooks_test.rb
+++ b/test/unit/hooks_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class HooksTest < ActiveSupport::TestCase
+  test "solid_queue_record hook ran" do
+    assert Rails.application.config.x.solid_queue_record_hook_ran
+  end
+end


### PR DESCRIPTION
We can use these to point to a different database:

E.g:
```
ActiveSupport.on_load(:solid_queue_record) do
  connects_to database: { writing: :solid_queue }
end
```