### PR TITLE
Add `SolidQueue.supervisor?` to determine whether we're running as a SQ supervisor process

### DIFF
--- a/lib/solid_queue.rb
+++ b/lib/solid_queue.rb
@@ -28,4 +28,9 @@ module SolidQueue
   mattr_accessor :shutdown_timeout, default: 5.seconds
 
   mattr_accessor :supervisor_pidfile
+  mattr_accessor :supervisor, default: false
+
+  def self.supervisor?
+    supervisor
+  end
 end

--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -6,6 +6,7 @@ module SolidQueue
 
     class << self
       def start(mode: :work, load_configuration_from: nil)
+        SolidQueue.supervisor = true
         configuration = Configuration.new(mode: mode, load_from: load_configuration_from)
 
         new(configuration.runners).start


### PR DESCRIPTION
We only want to do certain things in that case, such as emitting global metrics.