### PR TITLE
Allow multiple workers for the same queue and configuration

### DIFF
--- a/lib/solid_queue/queue_parser.rb
+++ b/lib/solid_queue/queue_parser.rb
@@ -4,8 +4,8 @@ module SolidQueue
   class QueueParser
     attr_reader :raw_queues, :relation
 
-    def initialize(queue_string, relation)
-      @raw_queues = queue_string.split(",").map(&:strip).presence || [ "*" ]
+    def initialize(queue_list, relation)
+      @raw_queues = Array(queue_list).map(&:strip).presence || [ "*" ]
       @relation = relation
     end
 

--- a/lib/solid_queue/worker.rb
+++ b/lib/solid_queue/worker.rb
@@ -10,8 +10,8 @@ module SolidQueue
       options = options.dup.with_defaults(SolidQueue::Configuration::WORKER_DEFAULTS)
 
       @polling_interval = options[:polling_interval]
-      @queues = options[:queues].to_s
-      @pool = Pool.new(options[:pool_size], on_idle: -> { wake_up })
+      @queues = options[:queues]
+      @pool = Pool.new(options[:threads], on_idle: -> { wake_up })
     end
 
     private
@@ -42,7 +42,7 @@ module SolidQueue
       end
 
       def metadata
-        super.merge(queues: queues, pool_size: pool.size, idle_threads: pool.idle_threads, polling_interval: polling_interval)
+        super.merge(queues: queues, thread_pool_size: pool.size, idle_threads: pool.idle_threads, polling_interval: polling_interval)
       end
   end
 end

--- a/test/dummy/config/solid_queue.yml
+++ b/test/dummy/config/solid_queue.yml
@@ -1,9 +1,9 @@
 default: &default
   workers:
-    background:
-      pool_size: 3
-    default:
-      pool_size: 5
+    - queues: background
+      threads: 3
+    - queues: default
+      threads: 5
   scheduler:
     polling_interval: 1
     batch_size: 500

--- a/test/integration/jobs_lifecycle_test.rb
+++ b/test/integration/jobs_lifecycle_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 
 class JobsLifecycleTest < ActiveSupport::TestCase
   setup do
-    @worker = SolidQueue::Worker.new(queue_name: "background", pool_size: 3, polling_interval: 1)
+    @worker = SolidQueue::Worker.new(queues: "background", threads: 3, polling_interval: 1)
     @scheduler = SolidQueue::Scheduler.new(batch_size: 10, polling_interval: 1)
   end
 

--- a/test/models/solid_queue/ready_execution_test.rb
+++ b/test/models/solid_queue/ready_execution_test.rb
@@ -55,7 +55,7 @@ class SolidQueue::ReadyExecutionTest < ActiveSupport::TestCase
     (SolidQueue::Job.all - @jobs).each(&:prepare_for_execution)
 
     assert_claimed_jobs(SolidQueue::Job.count) do
-      SolidQueue::ReadyExecution.claim("fixtures,background", SolidQueue::Job.count + 1, 42)
+      SolidQueue::ReadyExecution.claim(%w[ fixtures background ], SolidQueue::Job.count + 1, 42)
     end
   end
 
@@ -93,7 +93,7 @@ class SolidQueue::ReadyExecutionTest < ActiveSupport::TestCase
     (SolidQueue::Job.all - @jobs).each(&:prepare_for_execution)
 
     assert_claimed_jobs(SolidQueue::Job.count) do
-      SolidQueue::ReadyExecution.claim("fix*,background", SolidQueue::Job.count + 1, 42)
+      SolidQueue::ReadyExecution.claim(%w[ fix* background ], SolidQueue::Job.count + 1, 42)
     end
   end
 

--- a/test/unit/worker_test.rb
+++ b/test/unit/worker_test.rb
@@ -5,7 +5,7 @@ class WorkerTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
 
   setup do
-    @worker = SolidQueue::Worker.new(queue_name: "background", pool_size: 3, polling_interval: 10)
+    @worker = SolidQueue::Worker.new(queues: "background", threads: 3, polling_interval: 10)
   end
 
   teardown do


### PR DESCRIPTION
From @djmb:

> A single worker won't use more than 1 CPU core, so if you need to
> dedicate more than on CPU core on a VM to a queue you'll need multiple
> workers. I think I'll need this for the new campfire

This changes the configuration format to be like this:

```
workers:
    - queues: haystack_production_incineration
      processes: 3
      threads: 4
      polling_interval: 2
    - queues: haystack_production_recycling
      threads: 3
      polling_interval: 5
```

`processes` is 1 by default, and `queues` should be now an array of queues (which can include wildcards). 