### PR TITLE
Add missing foreign_key for supervisor <-> forks association, needed in Rails < 7.1

### DIFF
--- a/app/models/solid_queue/process.rb
+++ b/app/models/solid_queue/process.rb
@@ -2,7 +2,7 @@ class SolidQueue::Process < SolidQueue::Record
   include Prunable
 
   belongs_to :supervisor, class_name: "SolidQueue::Process", optional: true, inverse_of: :forks
-  has_many :forks, class_name: "SolidQueue::Process", inverse_of: :supervisor, dependent: :destroy
+  has_many :forks, class_name: "SolidQueue::Process", inverse_of: :supervisor, foreign_key: :supervisor_id, dependent: :destroy
   has_many :claimed_executions
 
   store :metadata, accessors: [ :kind, :pid ], coder: JSON

--- a/test/integration/processes_lifecycle_test.rb
+++ b/test/integration/processes_lifecycle_test.rb
@@ -77,7 +77,6 @@ class ProcessLifecycleTest < ActiveSupport::TestCase
     # Workers were shutdown without a chance to terminate orderly, but
     # since they're linked to the supervisor, the supervisor deregistering
     # also deregistered them and released claimed jobs
-    # Processes didn't have a chance to deregister either
     assert_clean_termination
   end
 


### PR DESCRIPTION
Thanks to @lewispb for spotting the error in Sentry.