### PR TITLE
Simplify ready execution claiming, passing only job_ids

### DIFF
--- a/app/models/solid_queue/claimed_execution.rb
+++ b/app/models/solid_queue/claimed_execution.rb
@@ -7,14 +7,12 @@ class SolidQueue::ClaimedExecution < SolidQueue::Execution
     end
   end
 
-  CLAIM_ATTRIBUTES = %w[ job_id ]
-
   class << self
-    def claiming(executions, process_id, &block)
-      job_data = Array(executions).collect { |execution| { job_id: execution.job_id, process_id: process_id } }
+    def claiming(job_ids, process_id, &block)
+      job_data = Array(job_ids).collect { |job_id| { job_id: job_id, process_id: process_id } }
 
       insert_all(job_data)
-      where(job_id: job_data.map { |data| data[:job_id]} ).tap do |claimed|
+      where(job_id: job_ids).tap do |claimed|
         block.call(claimed)
         SolidQueue.logger.info("[SolidQueue] Claimed #{claimed.size} jobs")
       end

--- a/app/models/solid_queue/ready_execution.rb
+++ b/app/models/solid_queue/ready_execution.rb
@@ -19,7 +19,7 @@ module SolidQueue
 
       private
         def select_candidates(queues, limit)
-          queued_as(queues).not_paused.ordered.limit(limit).lock("FOR UPDATE SKIP LOCKED")
+          queued_as(queues).not_paused.ordered.limit(limit).lock("FOR UPDATE SKIP LOCKED").pluck(:job_id)
         end
 
         def lock(candidates, process_id)
@@ -32,7 +32,7 @@ module SolidQueue
 
     def claim(process_id)
       transaction do
-        SolidQueue::ClaimedExecution.claiming(self, process_id) do |claimed|
+        SolidQueue::ClaimedExecution.claiming(job_id, process_id) do |claimed|
           delete if claimed.one?
         end
       end


### PR DESCRIPTION
We no longer need to pass executions, as that was a change to prepare for an implementation of sequential jobs that I won't be pursuing. We can simply pluck the `job_ids` of the selected executions, which, as a side-effect, avoids an extra query due to counting the jobs before actually trying to claim them.

Thanks to @djmb for spotting the extra `exists?` query that was a consequence of this change.