### PR TITLE
Silence scheduler polling

### DIFF
--- a/lib/solid_queue/runner.rb
+++ b/lib/solid_queue/runner.rb
@@ -104,5 +104,13 @@ module SolidQueue
       def running_inline?
         mode.inline?
       end
+
+      def with_polling_volume
+        if SolidQueue.silence_polling?
+          ActiveRecord::Base.logger.silence { yield }
+        else
+          yield
+        end
+      end
   end
 end

--- a/lib/solid_queue/scheduler.rb
+++ b/lib/solid_queue/scheduler.rb
@@ -14,15 +14,17 @@ class SolidQueue::Scheduler
 
   private
     def run
-      batch = SolidQueue::ScheduledExecution.next_batch(batch_size)
+      with_polling_volume do
+        batch = SolidQueue::ScheduledExecution.next_batch(batch_size)
 
-      if batch.size > 0
-        procline "preparing #{batch.size} jobs for execution"
+        if batch.size > 0
+          procline "preparing #{batch.size} jobs for execution"
 
-        SolidQueue::ScheduledExecution.prepare_batch(batch)
-      else
-        procline "waiting"
-        interruptible_sleep(polling_interval)
+          SolidQueue::ScheduledExecution.prepare_batch(batch)
+        else
+          procline "waiting"
+          interruptible_sleep(polling_interval)
+        end
       end
     end
 

--- a/lib/solid_queue/worker.rb
+++ b/lib/solid_queue/worker.rb
@@ -46,13 +46,5 @@ module SolidQueue
       def metadata
         super.merge(queues: queues, thread_pool_size: pool.size, idle_threads: pool.idle_threads, polling_interval: polling_interval)
       end
-
-      def with_polling_volume
-        if SolidQueue.silence_polling?
-          ActiveRecord::Base.logger.silence { yield }
-        else
-          yield
-        end
-      end
   end
 end

--- a/test/unit/scheduler_test.rb
+++ b/test/unit/scheduler_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+require "active_support/testing/method_call_assertions"
+
+class SchedulerTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::MethodCallAssertions
+
+  setup do
+    @scheduler = SolidQueue::Scheduler.new(polling_interval: 0.1, batch_size: 10)
+  end
+
+  teardown do
+    @scheduler.stop if @scheduler.running?
+  end
+
+  test "polling queries are logged" do
+    log = StringIO.new
+    old_logger, ActiveRecord::Base.logger = ActiveRecord::Base.logger, ActiveSupport::Logger.new(log)
+    old_silence_polling, SolidQueue.silence_polling = SolidQueue.silence_polling, false
+
+    @scheduler.start(mode: :async)
+    sleep 0.5
+
+    assert_match /SELECT .* FROM .solid_queue_scheduled_executions. WHERE/, log.string
+  ensure
+    ActiveRecord::Base.logger = old_logger
+    SolidQueue.silence_polling = old_silence_polling
+  end
+
+  test "polling queries can be silenced" do
+    log = StringIO.new
+    old_logger, ActiveRecord::Base.logger = ActiveRecord::Base.logger, ActiveSupport::Logger.new(log)
+    old_silence_polling, SolidQueue.silence_polling = SolidQueue.silence_polling, true
+
+    @scheduler.start(mode: :async)
+    sleep 0.5
+
+    assert_no_match /SELECT .* FROM .solid_queue_scheduled_executions. WHERE/, log.string
+  ensure
+    ActiveRecord::Base.logger = old_logger
+    SolidQueue.silence_polling = old_silence_polling
+  end
+end


### PR DESCRIPTION
Use SolidQueue.silence_polling to also silence the scheduler.

Following on from https://github.com/basecamp/solid_queue/pull/37, also silence the scheduler's polling.

cc @rosa 