### PR TITLE
Remove support for prefix matching in queues assigned to a worker

### DIFF
--- a/lib/solid_queue/queue_parser.rb
+++ b/lib/solid_queue/queue_parser.rb
@@ -12,7 +12,7 @@ module SolidQueue
     def scoped_relation
       if all? then relation.all
       else
-        by_exact_names.or(by_prefixes)
+        by_exact_names
       end
     end
 
@@ -25,16 +25,8 @@ module SolidQueue
         exact_names.any? ? relation.where(queue_name: exact_names) : relation.none
       end
 
-      def by_prefixes
-        prefixes.any? ? relation.where(([ "queue_name LIKE ?" ] * prefixes.count).join(" OR "), *prefixes) : relation.none
-      end
-
       def exact_names
         @exact_names ||= raw_queues.select { |queue| !queue.include?("*") }
-      end
-
-      def prefixes
-        @prefixes ||= raw_queues.select { |queue| queue.ends_with?("*") }.map { |queue| queue.tr("*", "%") }
       end
   end
 end

--- a/test/models/solid_queue/ready_execution_test.rb
+++ b/test/models/solid_queue/ready_execution_test.rb
@@ -80,21 +80,11 @@ class SolidQueue::ReadyExecutionTest < ActiveSupport::TestCase
     end
   end
 
-  test "claim jobs using queue prefixes" do
-    AddToBufferJob.perform_later("hey")
-
-    assert_claimed_jobs(1) do
-      SolidQueue::ReadyExecution.claim("backgr*", SolidQueue::Job.count + 1, 42)
-    end
-
-    assert @jobs.none?(&:claimed?)
-  end
-
-  test "claim jobs using both exact names and prefixes" do
+  test "claim jobs using both exact names and a wildcard" do
     AddToBufferJob.perform_later("hey")
 
     assert_claimed_jobs(6) do
-      SolidQueue::ReadyExecution.claim(%w[ backe* background ], SolidQueue::Job.count + 1, 42)
+      SolidQueue::ReadyExecution.claim(%w[ * background ], SolidQueue::Job.count + 1, 42)
     end
   end
 

--- a/test/unit/worker_test.rb
+++ b/test/unit/worker_test.rb
@@ -61,7 +61,7 @@ class WorkerTest < ActiveSupport::TestCase
     @worker.start(mode: :async)
     sleep 0.5
 
-    assert_match /SELECT .* FROM .solid_queue_ready_executions. WHERE \(.solid_queue_ready_executions...queue_name./, log.string
+    assert_match /SELECT .* FROM .solid_queue_ready_executions. WHERE .solid_queue_ready_executions...queue_name./, log.string
   ensure
     ActiveRecord::Base.logger = old_logger
     SolidQueue.silence_polling = old_silence_polling
@@ -75,7 +75,7 @@ class WorkerTest < ActiveSupport::TestCase
     @worker.start(mode: :async)
     sleep 0.5
 
-    assert_no_match /SELECT .* FROM .solid_queue_ready_executions. WHERE \(.solid_queue_ready_executions...queue_name./, log.string
+    assert_no_match /SELECT .* FROM .solid_queue_ready_executions. WHERE .solid_queue_ready_executions...queue_name./, log.string
   ensure
     ActiveRecord::Base.logger = old_logger
     SolidQueue.silence_polling = old_silence_polling


### PR DESCRIPTION
This would generate queries like
```
  WHERE `solid_queue_ready_executions.queue_name` LIKE 'prefix%'
```
that aren't performant enough due to the sorting by priority, so we've decided not to support these for now.

Thanks to @djmb for the assistance with this.