### PR TITLE
Bring back support for prefix matching in queues assigned to a worker

### DIFF
--- a/app/models/solid_queue/pause.rb
+++ b/app/models/solid_queue/pause.rb
@@ -1,7 +1,4 @@
 module SolidQueue
   class Pause < Record
-    def self.all_queue_names
-      all.pluck(:queue_name)
-    end
   end
 end

--- a/lib/solid_queue/queue_selector.rb
+++ b/lib/solid_queue/queue_selector.rb
@@ -20,7 +20,7 @@ module SolidQueue
       def queue_names
         if all? then filter_paused_queues
         else
-          filter_paused_queues(exact_names)
+          filter_paused_queues(exact_names + prefixed_names)
         end
       end
 
@@ -29,16 +29,32 @@ module SolidQueue
       end
 
       def filter_paused_queues(queues = [])
-        paused_queues = Pause.all_queue_names
+        paused_queues = Pause.all.pluck(:queue_name)
+
         if paused_queues.empty? then queues
         else
-          queues = queues.presence || Queue.all.map(&:name)
+          queues = queues.presence || all_queue_names
           queues - paused_queues
         end
       end
 
       def exact_names
         @exact_names ||= raw_queues.select { |queue| !queue.include?("*") }
+      end
+
+      def prefixed_names
+        if prefixes.empty? then []
+        else
+          relation.where(([ "queue_name LIKE ?" ] * prefixes.count).join(" OR "), *prefixes).distinct(:queue_name).pluck(:queue_name)
+        end
+      end
+
+      def prefixes
+        @prefixes ||= raw_queues.select { |queue| queue.ends_with?("*") }.map { |queue| queue.tr("*", "%") }
+      end
+
+      def all_queue_names
+        relation.distinct(:queue_name).pluck(:queue_name)
       end
   end
 end

--- a/test/models/solid_queue/ready_execution_test.rb
+++ b/test/models/solid_queue/ready_execution_test.rb
@@ -88,6 +88,16 @@ class SolidQueue::ReadyExecutionTest < ActiveSupport::TestCase
     end
   end
 
+  test "claim jobs using queue prefixes" do
+    AddToBufferJob.perform_later("hey")
+
+    assert_claimed_jobs(1) do
+      SolidQueue::ReadyExecution.claim("backgr*", SolidQueue::Job.count + 1, 42)
+    end
+
+    assert @jobs.none?(&:claimed?)
+  end
+
   test "claim jobs using a wildcard and having paused queues" do
     AddToBufferJob.perform_later("hey")
 
@@ -101,11 +111,11 @@ class SolidQueue::ReadyExecutionTest < ActiveSupport::TestCase
     assert @jobs.none?(&:claimed?)
   end
 
-  test "claim jobs using both exact names and a wildcard" do
+  test "claim jobs using both exact names and a prefixes" do
     AddToBufferJob.perform_later("hey")
 
     assert_claimed_jobs(6) do
-      SolidQueue::ReadyExecution.claim(%w[ * background ], SolidQueue::Job.count + 1, 42)
+      SolidQueue::ReadyExecution.claim(%w[ backe* background ], SolidQueue::Job.count + 1, 42)
     end
   end
 


### PR DESCRIPTION
This was removed in https://github.com/basecamp/solid_queue/pull/45, as the resulting queries for polling using `queue_name LIKE 'something%'` were very slow as they prevented MySQL from using an index for ordering. The idea after removing that was to support namespaces so we could combine a namespace with a `"*"` for queue names, to have support for a single prefix. However, namespaces felt like too big of a change just to accommodate our staging and beta setups, so I've brought this back, but this time with a different implementation, based on fetching the list of queue names relevant for polling, filtering there with the prefix. This query is very fast because it can use an existing index starting with `queue_name` and apply [the Loose Index Scan technique](https://dev.mysql.com/doc/refman/8.0/en/group-by-optimization.html#loose-index-scan) to examine as many rows as distinct values there are.