### PR TITLE
Make sure all queues are included in the selection only when `*` is specified

### DIFF
--- a/lib/solid_queue/queue_selector.rb
+++ b/lib/solid_queue/queue_selector.rb
@@ -10,36 +10,40 @@ module SolidQueue
     end
 
     def scoped_relations
-      if queue_names.empty? then [ relation.all ]
+      case
+      when all?  then [ relation.all ]
+      when none? then [ relation.none ]
       else
         queue_names.map { |queue_name| relation.queued_as(queue_name) }
       end
     end
 
     private
+      def all?
+        include_all_queues? && paused_queues.empty?
+      end
+
+      def none?
+        queue_names.empty?
+      end
+
       def queue_names
-        if all? then filter_paused_queues
+        @queue_names ||= eligible_queues - paused_queues
+      end
+
+      def eligible_queues
+        if include_all_queues? then all_queues
         else
-          filter_paused_queues(exact_names + prefixed_names)
+          exact_names + prefixed_names
         end
       end
 
-      def all?
+      def include_all_queues?
         "*".in? raw_queues
       end
 
-      def filter_paused_queues(queues = [])
-        paused_queues = Pause.all.pluck(:queue_name)
-
-        if paused_queues.empty? then queues
-        else
-          queues = queues.presence || all_queue_names
-          queues - paused_queues
-        end
-      end
-
       def exact_names
-        @exact_names ||= raw_queues.select { |queue| !queue.include?("*") }
+        raw_queues.select { |queue| !queue.include?("*") }
       end
 
       def prefixed_names
@@ -53,8 +57,12 @@ module SolidQueue
         @prefixes ||= raw_queues.select { |queue| queue.ends_with?("*") }.map { |queue| queue.tr("*", "%") }
       end
 
-      def all_queue_names
+      def all_queues
         relation.distinct(:queue_name).pluck(:queue_name)
+      end
+
+      def paused_queues
+        @paused_queues ||= Pause.all.pluck(:queue_name)
       end
   end
 end

--- a/test/models/solid_queue/ready_execution_test.rb
+++ b/test/models/solid_queue/ready_execution_test.rb
@@ -119,9 +119,17 @@ class SolidQueue::ReadyExecutionTest < ActiveSupport::TestCase
     end
   end
 
+  test "claim jobs for queue without jobs at the moment using prefixes" do
+    AddToBufferJob.perform_later("hey")
+
+    assert_claimed_jobs(0) do
+      SolidQueue::ReadyExecution.claim(%w[ none* ], SolidQueue::Job.count + 1, 42)
+    end
+  end
+
   private
     def assert_claimed_jobs(count, &block)
-      assert_difference -> { SolidQueue::ReadyExecution.count } => -count, -> { SolidQueue::ClaimedExecution.count } => +count do
+      assert_difference -> { SolidQueue::ClaimedExecution.count } => +count, -> { SolidQueue::ReadyExecution.count } => -count do
         block.call
       end
     end


### PR DESCRIPTION
Before, if no _queue_name_ was found matching the given prefix, we'd just select all queues.