### PR TITLE
Add a scope for SolidQueue::Job.clearable, so we can use it independently

### DIFF
--- a/app/models/solid_queue/job/clearable.rb
+++ b/app/models/solid_queue/job/clearable.rb
@@ -3,9 +3,13 @@ module SolidQueue
     module Clearable
       extend ActiveSupport::Concern
 
+      included do
+        scope :clearable, ->(finished_before: SolidQueue.clear_finished_jobs_after.ago) { where.not(finished_at: nil).where(finished_at: ...finished_before) }
+      end
+
       class_methods do
         def clear_finished_in_batches(batch_size: 500, finished_before: SolidQueue.clear_finished_jobs_after.ago)
-          where.not(finished_at: nil).where(finished_at: ...finished_before).in_batches(of: batch_size).delete_all
+          clearable(finished_before: finished_before).in_batches(of: batch_size).delete_all
         end
       end
     end


### PR DESCRIPTION
We need to give an index hint for clearing jobs in HEY due to how our `solid_queue_jobs` table gets clearable jobs randomly by ID instead of mostly ordered.