### PR TITLE
Default to a single worker with default settings when no config is provided

### DIFF
--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -3,6 +3,7 @@
 module SolidQueue
   class Configuration
     WORKER_DEFAULTS = {
+      queues: "*",
       threads: 5,
       processes: 1,
       polling_interval: 0.1
@@ -10,7 +11,7 @@ module SolidQueue
 
     DISPATCHER_DEFAULTS = {
       batch_size: 500,
-      polling_interval: 5,
+      polling_interval: 1,
       concurrency_maintenance_interval: 600
     }
 
@@ -61,7 +62,7 @@ module SolidQueue
       end
 
       def workers_options
-        @workers_options ||= (raw_config[:workers] || {}).map { |options| options.dup.symbolize_keys }
+        @workers_options ||= (raw_config[:workers] || [ WORKER_DEFAULTS ]).map { |options| options.dup.symbolize_keys }
       end
 
       def dispatcher_options

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -1,6 +1,17 @@
 require "test_helper"
 
 class ConfigurationTest < ActiveSupport::TestCase
+  test "default configuration to process all queues and dispatch" do
+    configuration = SolidQueue::Configuration.new(mode: :all, load_from: {})
+    assert_equal 2, configuration.processes.count
+
+    assert_equal 1, configuration.workers.count
+    assert configuration.dispatcher.present?
+
+    assert_equal [ "*" ], configuration.workers.first.queues
+    assert_equal SolidQueue::Configuration::DISPATCHER_DEFAULTS[:batch_size], configuration.dispatcher.batch_size
+  end
+
   test "read configuration from default file" do
     configuration = SolidQueue::Configuration.new(mode: :all)
     assert 3, configuration.processes.count


### PR DESCRIPTION
In this way, someone just starting Solid Queue will have something that dispatches and processes jobs without having to worry about a configuration file.

Also: make the default queues (all queues, `"*"`) explicit.