### PR TITLE
Use SKIP LOCKED by default but allow not using it if not supported

### DIFF
--- a/app/models/solid_queue/blocked_execution.rb
+++ b/app/models/solid_queue/blocked_execution.rb
@@ -22,7 +22,7 @@ module SolidQueue
 
       def release_one(concurrency_key)
         transaction do
-          ordered.where(concurrency_key: concurrency_key).limit(1).lock("FOR UPDATE SKIP LOCKED").each(&:release)
+          ordered.where(concurrency_key: concurrency_key).limit(1).lock.each(&:release)
         end
       end
 

--- a/app/models/solid_queue/process/prunable.rb
+++ b/app/models/solid_queue/process/prunable.rb
@@ -7,7 +7,7 @@ module SolidQueue::Process::Prunable
 
   class_methods do
     def prune
-      prunable.lock("FOR UPDATE SKIP LOCKED").find_in_batches(batch_size: 50) do |batch|
+      prunable.lock.find_in_batches(batch_size: 50) do |batch|
         batch.each do |process|
           SolidQueue.logger.info("[SolidQueue] Pruning dead process #{process.id} - #{process.metadata}")
           process.deregister

--- a/app/models/solid_queue/ready_execution.rb
+++ b/app/models/solid_queue/ready_execution.rb
@@ -24,7 +24,7 @@ module SolidQueue
         end
 
         def select_candidates(queue_relation, limit)
-          queue_relation.ordered.limit(limit).lock("FOR UPDATE SKIP LOCKED").pluck(:job_id)
+          queue_relation.ordered.limit(limit).lock.pluck(:job_id)
         end
 
         def lock_candidates(job_ids, process_id)

--- a/app/models/solid_queue/record.rb
+++ b/app/models/solid_queue/record.rb
@@ -3,6 +3,14 @@ module SolidQueue
     self.abstract_class = true
 
     connects_to **SolidQueue.connects_to if SolidQueue.connects_to
+
+    def self.lock(...)
+      if SolidQueue.use_skip_locked
+        super(Arel.sql("FOR UPDATE SKIP LOCKED"))
+      else
+        super
+      end
+    end
   end
 end
 

--- a/app/models/solid_queue/scheduled_execution.rb
+++ b/app/models/solid_queue/scheduled_execution.rb
@@ -9,7 +9,7 @@ module SolidQueue
     class << self
       def dispatch_next_batch(batch_size)
         transaction do
-          job_ids = next_batch(batch_size).lock("FOR UPDATE SKIP LOCKED").pluck(:job_id)
+          job_ids = next_batch(batch_size).lock.pluck(:job_id)
           if job_ids.empty? then []
           else
             dispatch_batch(job_ids)

--- a/lib/solid_queue.rb
+++ b/lib/solid_queue.rb
@@ -24,6 +24,8 @@ module SolidQueue
   mattr_accessor :logger, default: ActiveSupport::Logger.new($stdout)
   mattr_accessor :app_executor, :on_thread_error, :connects_to
 
+  mattr_accessor :use_skip_locked, default: true
+
   mattr_accessor :process_heartbeat_interval, default: 60.seconds
   mattr_accessor :process_alive_threshold, default: 5.minutes
 


### PR DESCRIPTION
This is a setting for now, but will be automatically detected on start later.