### PR TITLE
Use ActiveRecord::Migration[7.0] in migrations

### DIFF
--- a/db/migrate/20231211200639_create_solid_queue_tables.rb
+++ b/db/migrate/20231211200639_create_solid_queue_tables.rb
@@ -1,4 +1,4 @@
-class CreateSolidQueueTables < ActiveRecord::Migration[7.1]
+class CreateSolidQueueTables < ActiveRecord::Migration[7.0]
   def change
     create_table :solid_queue_jobs do |t|
       t.string :queue_name, null: false


### PR DESCRIPTION
Hey,

First of all, thank you so much for amazing Solid Queue! ❤️

Migrations are using version 7.1, but support is provided from Rails 7.0 onwards, so users installing migrations using Rails 7.0 will get an error and will have to manually change the version of the migrations class. This PR fixes that.