### PR TITLE
Update example for all queues sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ production:
     - polling_interval: 1
       batch_size: 500
   workers:
-    - queues: *
+    - queues: "*"
       threads: 3
       polling_interval: 2
     - queues: real_time,background


### PR DESCRIPTION
Without it, I'm getting error:
```
YAML syntax error occurred while parsing /path-to-app/config/solid_queue.yml. Please note that YAML must be consistently indented using spaces. Tabs are not allowed. Error: (<unknown>): did not find expected alphabetic or numeric character while scanning an alias at line 6 column 15
```
when starting `bundle exec rake solid_queue:start`

Please note that the latter example `staging*` works fine as is.