### PR TITLE
Copy over example config on install

### DIFF
--- a/lib/generators/solid_queue/install/install_generator.rb
+++ b/lib/generators/solid_queue/install/install_generator.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class SolidQueue::InstallGenerator < Rails::Generators::Base
+  source_root File.expand_path("templates", __dir__)
+
   class_option :skip_migrations, type: :boolean, default: nil, desc: "Skip migrations"
 
   def add_solid_queue
@@ -9,6 +11,8 @@ class SolidQueue::InstallGenerator < Rails::Generators::Base
         gsub_file env_config, /(# )?config\.active_job\.queue_adapter\s+=.*/, "config.active_job.queue_adapter = :solid_queue"
       end
     end
+
+    copy_file "config.yml", "config/solid_queue.yml"
   end
 
   def create_migrations

--- a/lib/generators/solid_queue/install/templates/config.yml
+++ b/lib/generators/solid_queue/install/templates/config.yml
@@ -1,0 +1,18 @@
+#default: &default
+#   dispatchers:
+#     - polling_interval: 1
+#       batch_size: 500
+#   workers:
+#     - queues: "*"
+#       threads: 5
+#       processes: 1
+#       polling_interval: 0.1
+#
+# development:
+#  <<: *default
+#
+# test:
+#  <<: *default
+#
+# production:
+#  <<: *default


### PR DESCRIPTION
The install steps eluded to a configuration not needed (an empty file will suffice) so I ran the install generator and ran into this error.

```bash
± bundle exec rails solid_queue:start
bin/rails aborted!
Configuration for Solid Queue not found in /Users/chris/code/solidqueue-example/config/solid_queue.yml

Tasks: TOP => solid_queue:start
(See full trace by running task with --trace)
```

This PR adds an example `config/solid_queue.yml` file to the generator to fix this error on install and provide an easy to customize example config.

Should make it a bit easier to use and customize. 👍 

Thanks for all your hard work @rosa!!

Edit: I just saw on your other PR that you were going to delete the generator, so feel free to close this if you want. This might be a useful reason to keep the generator?