### PR TITLE
Fix indentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ If you prefer not to rely on this, or avoid relying on it unintentionally, you s
   ```
 
   ```ruby
-  solid_queue.config.connects_to { database: { writing: :primary, reading: :replica } }
+  config.solid_queue.connects_to = { database: { writing: :primary, reading: :replica } }
   ```
 
 ## Inspiration


### PR DESCRIPTION
This fixes the indentation of a few multi-paragraph list items.

| Before | After |
| --- | --- |
| ![before](https://github.com/basecamp/solid_queue/assets/771968/9a11ea3a-ae7e-4329-85c0-01e9a6d41a64) | ![after](https://github.com/basecamp/solid_queue/assets/771968/0784c11c-8f41-4b05-9501-1a00668902d1) |

I also snuck in a 2nd commit that fixes a typo in a configuration example: `solid_queue.config.connects_to` => `config.solid_queue.connects_to`.
