### PR TITLE
Make sure we wrap runnable code in app's executor.

### DIFF
--- a/lib/solid_queue/processes/runnable.rb
+++ b/lib/solid_queue/processes/runnable.rb
@@ -44,7 +44,9 @@ module SolidQueue::Processes
       loop do
         break if shutting_down?
 
-        run
+        wrap_in_app_executor do
+          run
+        end
       end
     ensure
       run_callbacks(:shutdown) { shutdown }


### PR DESCRIPTION
closes https://github.com/basecamp/solid_queue/issues/75