### PR TITLE
feature: add failed scope to job

### DIFF
--- a/app/models/solid_queue/job/executable.rb
+++ b/app/models/solid_queue/job/executable.rb
@@ -17,6 +17,7 @@ module SolidQueue
         after_create :prepare_for_execution
 
         scope :finished, -> { where.not(finished_at: nil) }
+        scope :failed, -> { includes(:failed_execution).where.not(failed_execution: {id: nil}) }
       end
 
       %w[ ready claimed failed scheduled ].each do |status|


### PR DESCRIPTION
I think it's useful and a common thing to query all the failed jobs.
I added a scope for it.