### PR TITLE
Run Supervisor only when puma is fully booted.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,8 @@ GEM
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
     pg (1.5.4)
+    puma (6.4.0)
+      nio4r (~> 2.0)
     racc (1.7.1)
     rack (3.0.8)
     rack-session (2.0.0)
@@ -194,6 +196,7 @@ DEPENDENCIES
   mocha
   mysql2
   pg
+  puma
   solid_queue!
   sqlite3
 

--- a/solid_queue.gemspec
+++ b/solid_queue.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", ">= 7.0.3.1"
   spec.add_development_dependency "debug"
   spec.add_development_dependency "mocha"
+  spec.add_development_dependency "puma"
 end

--- a/test/dummy/config/puma.rb
+++ b/test/dummy/config/puma.rb
@@ -41,3 +41,4 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
+plugin :solid_queue

--- a/test/integration/puma/plugin_test.rb
+++ b/test/integration/puma/plugin_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require "test_helper"
+
+class PumaPluginTest < ActiveSupport::TestCase
+  self.use_transactional_tests = false
+
+  setup do
+    cmd = %w[
+      bundle exec puma
+        -b tcp://127.0.0.1:9222
+        -C test/dummy/config/puma.rb
+        --dir test/dummy
+        -s
+        config.ru
+    ]
+
+    @pid = fork do
+      exec(*cmd)
+    end
+  end
+
+  teardown do
+    Process.kill :INT, @pid
+  end
+
+  test "perform jobs inside puma's process" do
+    StoreResultJob.perform_later(:puma_plugin)
+
+    wait_for_jobs_to_finish_for(1.second)
+    assert_equal 1, JobResult.where(queue_name: :background, status: "completed", value: :puma_plugin).count
+  end
+end


### PR DESCRIPTION
To be able to use app's code we need to wait for puma to boot before we start SolidQueue's supervisor. 

closes https://github.com/basecamp/solid_queue/issues/77