### PR TITLE
Implement `perform_all_later` via `enqueue_all`

### DIFF
--- a/app/models/solid_queue/blocked_execution.rb
+++ b/app/models/solid_queue/blocked_execution.rb
@@ -2,7 +2,7 @@
 
 module SolidQueue
   class BlockedExecution < Execution
-    assume_attributes_from_job :concurrency_key
+    assumes_attributes_from_job :concurrency_key
     before_create :set_expires_at
 
     has_one :semaphore, foreign_key: :key, primary_key: :concurrency_key

--- a/app/models/solid_queue/execution.rb
+++ b/app/models/solid_queue/execution.rb
@@ -11,5 +11,17 @@ module SolidQueue
     belongs_to :job
 
     alias_method :discard, :destroy
+
+    class << self
+      def create_all_from_jobs(jobs)
+        insert_all execution_data_from_jobs(jobs)
+      end
+
+      def execution_data_from_jobs(jobs)
+        jobs.collect do |job|
+          attributes_from_job(job).merge(job_id: job.id)
+        end
+      end
+    end
   end
 end

--- a/app/models/solid_queue/execution/job_attributes.rb
+++ b/app/models/solid_queue/execution/job_attributes.rb
@@ -5,17 +5,24 @@ module SolidQueue
     module JobAttributes
       extend ActiveSupport::Concern
 
-      ASSUMIBLE_ATTRIBUTES_FROM_JOB = %i[ queue_name priority ]
+      included do
+        class_attribute :assumible_attributes_from_job, instance_accessor: false, default: %i[ queue_name priority ]
+      end
 
       class_methods do
-        def assume_attributes_from_job(*attributes)
-          before_create -> { assume_attributes_from_job(ASSUMIBLE_ATTRIBUTES_FROM_JOB | attributes) }
+        def assumes_attributes_from_job(*attribute_names)
+          self.assumible_attributes_from_job |= attribute_names
+          before_create -> { assume_attributes_from_job }
+        end
+
+        def attributes_from_job(job)
+          job.attributes.symbolize_keys.slice(*assumible_attributes_from_job)
         end
       end
 
       private
-        def assume_attributes_from_job(attributes)
-          attributes.each do |attribute|
+        def assume_attributes_from_job
+          self.class.assumible_attributes_from_job.each do |attribute|
             send("#{attribute}=", job.send(attribute))
           end
         end

--- a/app/models/solid_queue/job.rb
+++ b/app/models/solid_queue/job.rb
@@ -13,24 +13,54 @@ class SolidQueue::Job < SolidQueue::Record
   DEFAULT_QUEUE_NAME = "default"
 
   class << self
-    def enqueue_active_job(active_job, scheduled_at: Time.current)
-      enqueue \
-        queue_name: active_job.queue_name,
-        active_job_id: active_job.job_id,
-        priority: active_job.priority,
-        scheduled_at: scheduled_at,
-        class_name: active_job.class.name,
-        arguments: active_job.serialize,
-        concurrency_key: active_job.try(:concurrency_key)
-    end
+    def enqueue_active_jobs(active_jobs)
+      scheduled_jobs, immediate_jobs = active_jobs.partition(&:scheduled_at)
+      with_concurrency_limits, without_concurrency_limits = immediate_jobs.partition(&:concurrency_limited?)
 
-    def enqueue(**kwargs)
-      create!(**kwargs.compact.with_defaults(defaults)).tap do
-        SolidQueue.logger.debug "[SolidQueue] Enqueued job #{kwargs}"
+      with_concurrency_limits.each do |active_job|
+        enqueue_active_job(active_job)
+      end
+
+      transaction do
+        job_rows = scheduled_jobs.map { |job| attributes_from_active_job(job) }
+        self.insert_all(job_rows)
+        inserted_jobs = where(active_job_id: scheduled_jobs.map(&:job_id))
+        execution_rows = inserted_jobs.map { |job| job.attributes.slice("queue_name", "priority", "scheduled_at").merge(job_id: job.id) }
+        SolidQueue::ScheduledExecution.insert_all(execution_rows)
+      end
+
+      transaction do
+        job_rows = without_concurrency_limits.map { |job| attributes_from_active_job(job) }
+        self.insert_all(job_rows)
+        inserted_jobs = where(active_job_id: without_concurrency_limits.map(&:job_id))
+        execution_rows = inserted_jobs.map { |job| job.attributes.slice("queue_name", "priority").merge(job_id: job.id) }
+        SolidQueue::ReadyExecution.insert_all(execution_rows)
       end
     end
 
+    def enqueue_active_job(active_job, scheduled_at: Time.current)
+      enqueue **attributes_from_active_job(active_job).reverse_merge(scheduled_at: scheduled_at)
+    end
+
     private
+      def enqueue(**kwargs)
+        create!(**kwargs).tap do
+          SolidQueue.logger.debug "[SolidQueue] Enqueued job #{kwargs}"
+        end
+      end
+
+      def attributes_from_active_job(active_job)
+        {
+          queue_name: active_job.queue_name,
+          active_job_id: active_job.job_id,
+          priority: active_job.priority,
+          scheduled_at: active_job.scheduled_at,
+          class_name: active_job.class.name,
+          arguments: active_job.serialize,
+          concurrency_key: active_job.concurrency_key
+        }.compact.with_defaults(defaults)
+      end
+
       def defaults
         { queue_name: DEFAULT_QUEUE_NAME, priority: DEFAULT_PRIORITY }
       end

--- a/app/models/solid_queue/job.rb
+++ b/app/models/solid_queue/job.rb
@@ -1,66 +1,74 @@
 # frozen_string_literal: true
 
-class SolidQueue::Job < SolidQueue::Record
-  include Executable
+module SolidQueue
+  class Job < Record
+    include Executable
 
-  if Gem::Version.new(Rails.version) >= Gem::Version.new("7.1")
-    serialize :arguments, coder: JSON
-  else
-    serialize :arguments, JSON
-  end
-
-  DEFAULT_PRIORITY = 0
-  DEFAULT_QUEUE_NAME = "default"
-
-  class << self
-    def enqueue_all_active_jobs(active_jobs)
-      scheduled_jobs, immediate_jobs = active_jobs.partition(&:scheduled_at)
-      with_concurrency_limits, without_concurrency_limits = immediate_jobs.partition(&:concurrency_limited?)
-
-      with_concurrency_limits.each do |active_job|
-        enqueue_active_job(active_job)
-      end
-
-      transaction do
-        job_rows = scheduled_jobs.map { |job| attributes_from_active_job(job) }
-        insert_all(job_rows)
-        inserted_jobs = where(active_job_id: scheduled_jobs.map(&:job_id))
-        SolidQueue::ScheduledExecution.create_all_from_jobs(inserted_jobs)
-      end
-
-      transaction do
-        job_rows = without_concurrency_limits.map { |job| attributes_from_active_job(job) }
-        insert_all(job_rows)
-        inserted_jobs = where(active_job_id: without_concurrency_limits.map(&:job_id))
-        SolidQueue::ReadyExecution.create_all_from_jobs(inserted_jobs)
-      end
+    if Gem::Version.new(Rails.version) >= Gem::Version.new("7.1")
+      serialize :arguments, coder: JSON
+    else
+      serialize :arguments, JSON
     end
 
-    def enqueue_active_job(active_job, scheduled_at: Time.current)
-      enqueue **attributes_from_active_job(active_job).reverse_merge(scheduled_at: scheduled_at)
-    end
+    class << self
+      def enqueue_all(active_jobs)
+        scheduled_jobs, immediate_jobs = active_jobs.partition(&:scheduled_at)
+        with_concurrency_limits, without_concurrency_limits = immediate_jobs.partition(&:concurrency_limited?)
 
-    private
-      def enqueue(**kwargs)
-        create!(**kwargs).tap do
-          SolidQueue.logger.debug "[SolidQueue] Enqueued job #{kwargs}"
+        schedule_all_at_once(scheduled_jobs)
+        enqueue_all_at_once(without_concurrency_limits)
+        enqueue_one_by_one(with_concurrency_limits)
+      end
+
+      def schedule_all_at_once(active_jobs)
+        transaction do
+          inserted_jobs = create_all_from_active_jobs(active_jobs)
+          schedule_all(inserted_jobs)
         end
       end
 
-      def attributes_from_active_job(active_job)
-        {
-          queue_name: active_job.queue_name,
-          active_job_id: active_job.job_id,
-          priority: active_job.priority,
-          scheduled_at: active_job.scheduled_at,
-          class_name: active_job.class.name,
-          arguments: active_job.serialize,
-          concurrency_key: active_job.concurrency_key
-        }.compact.with_defaults(defaults)
+      def enqueue_all_at_once(active_jobs)
+        transaction do
+          inserted_jobs = create_all_from_active_jobs(active_jobs)
+          dispatch_all_at_once(inserted_jobs)
+        end
       end
 
-      def defaults
-        { queue_name: DEFAULT_QUEUE_NAME, priority: DEFAULT_PRIORITY }
+      def enqueue_one_by_one(active_jobs)
+        active_jobs.each { |active_job| enqueue(active_job) }
       end
+
+      def enqueue(active_job, scheduled_at: Time.current)
+        create!(**attributes_from_active_job(active_job).reverse_merge(scheduled_at: scheduled_at)).tap do |job|
+          active_job.provider_job_id = job.id
+        end
+      end
+
+      private
+        DEFAULT_PRIORITY = 0
+        DEFAULT_QUEUE_NAME = "default"
+
+        def create_all_from_active_jobs(active_jobs)
+          job_rows = active_jobs.map { |job| attributes_from_active_job(job) }
+          insert_all(job_rows)
+          where(active_job_id: active_jobs.map(&:job_id))
+        end
+
+        def attributes_from_active_job(active_job)
+          {
+            queue_name: active_job.queue_name,
+            active_job_id: active_job.job_id,
+            priority: active_job.priority,
+            scheduled_at: active_job.scheduled_at,
+            class_name: active_job.class.name,
+            arguments: active_job.serialize,
+            concurrency_key: active_job.concurrency_key
+          }.compact.with_defaults(defaults)
+        end
+
+        def defaults
+          { queue_name: DEFAULT_QUEUE_NAME, priority: DEFAULT_PRIORITY }
+        end
+    end
   end
 end

--- a/app/models/solid_queue/job/executable.rb
+++ b/app/models/solid_queue/job/executable.rb
@@ -20,6 +20,16 @@ module SolidQueue
         scope :failed, -> { includes(:failed_execution).where.not(failed_execution: { id: nil }) }
       end
 
+      class_methods do
+        def dispatch_all_at_once(jobs)
+          ReadyExecution.create_all_from_jobs(jobs)
+        end
+
+        def schedule_all(jobs)
+          ScheduledExecution.create_all_from_jobs(jobs)
+        end
+      end
+
       %w[ ready claimed failed scheduled ].each do |status|
         define_method("#{status}?") { public_send("#{status}_execution").present? }
       end

--- a/app/models/solid_queue/job/executable.rb
+++ b/app/models/solid_queue/job/executable.rb
@@ -17,7 +17,7 @@ module SolidQueue
         after_create :prepare_for_execution
 
         scope :finished, -> { where.not(finished_at: nil) }
-        scope :failed, -> { includes(:failed_execution).where.not(failed_execution: {id: nil}) }
+        scope :failed, -> { includes(:failed_execution).where.not(failed_execution: { id: nil }) }
       end
 
       %w[ ready claimed failed scheduled ].each do |status|

--- a/app/models/solid_queue/ready_execution.rb
+++ b/app/models/solid_queue/ready_execution.rb
@@ -4,7 +4,7 @@ module SolidQueue
   class ReadyExecution < Execution
     scope :queued_as, ->(queue_name) { where(queue_name: queue_name) }
 
-    assume_attributes_from_job
+    assumes_attributes_from_job
 
     class << self
       def claim(queue_list, limit, process_id)

--- a/app/models/solid_queue/scheduled_execution.rb
+++ b/app/models/solid_queue/scheduled_execution.rb
@@ -22,24 +22,11 @@ module SolidQueue
       private
         def dispatch_batch(job_ids)
           jobs = Job.where(id: job_ids)
-          Job.dispatch_all(jobs)
 
-          successfully_dispatched(job_ids).tap do |dispatched_job_ids|
+          Job.dispatch_all(jobs).map(&:id).tap do |dispatched_job_ids|
             where(job_id: dispatched_job_ids).delete_all
             SolidQueue.logger.info("[SolidQueue] Dispatched scheduled batch with #{dispatched_job_ids.size} jobs")
           end
-        end
-
-        def successfully_dispatched(job_ids)
-          dispatched_and_ready(job_ids) + dispatched_and_blocked(job_ids)
-        end
-
-        def dispatched_and_ready(job_ids)
-          ReadyExecution.where(job_id: job_ids).pluck(:job_id)
-        end
-
-        def dispatched_and_blocked(job_ids)
-          BlockedExecution.where(job_id: job_ids).pluck(:job_id)
         end
     end
   end

--- a/app/models/solid_queue/scheduled_execution.rb
+++ b/app/models/solid_queue/scheduled_execution.rb
@@ -6,7 +6,7 @@ module SolidQueue
     scope :ordered, -> { order(scheduled_at: :asc, priority: :asc) }
     scope :next_batch, ->(batch_size) { due.ordered.limit(batch_size) }
 
-    assume_attributes_from_job :scheduled_at
+    assumes_attributes_from_job :scheduled_at
 
     class << self
       def dispatch_next_batch(batch_size)
@@ -34,17 +34,11 @@ module SolidQueue
         end
 
         def dispatch_at_once(jobs)
-          ReadyExecution.insert_all ready_rows_from_batch(jobs)
+          ReadyExecution.create_all_from_jobs jobs
         end
 
         def dispatch_one_by_one(jobs)
           jobs.each(&:dispatch)
-        end
-
-        def ready_rows_from_batch(jobs)
-          jobs.map do |job|
-            { job_id: job.id, queue_name: job.queue_name, priority: job.priority }
-          end
         end
 
         def successfully_dispatched(job_ids)

--- a/app/models/solid_queue/scheduled_execution.rb
+++ b/app/models/solid_queue/scheduled_execution.rb
@@ -42,10 +42,8 @@ module SolidQueue
         end
 
         def ready_rows_from_batch(jobs)
-          prepared_at = Time.current
-
           jobs.map do |job|
-            { job_id: job.id, queue_name: job.queue_name, priority: job.priority, created_at: prepared_at }
+            { job_id: job.id, queue_name: job.queue_name, priority: job.priority }
           end
         end
 

--- a/lib/active_job/concurrency_controls.rb
+++ b/lib/active_job/concurrency_controls.rb
@@ -36,6 +36,10 @@ module ActiveJob
       end
     end
 
+    def concurrency_limited?
+      concurrency_key.present?
+    end
+
     private
       def concurrency_group
         compute_concurrency_parameter(self.class.concurrency_group)

--- a/lib/active_job/queue_adapters/solid_queue_adapter.rb
+++ b/lib/active_job/queue_adapters/solid_queue_adapter.rb
@@ -21,7 +21,7 @@ module ActiveJob
       end
 
       def enqueue_all(active_jobs) # :nodoc:
-        SolidQueue::Job.enqueue_active_jobs(active_jobs)
+        SolidQueue::Job.enqueue_all_active_jobs(active_jobs)
       end
     end
   end

--- a/lib/active_job/queue_adapters/solid_queue_adapter.rb
+++ b/lib/active_job/queue_adapters/solid_queue_adapter.rb
@@ -9,19 +9,15 @@ module ActiveJob
     #   Rails.application.config.active_job.queue_adapter = :solid_queue
     class SolidQueueAdapter
       def enqueue(active_job) # :nodoc:
-        SolidQueue::Job.enqueue_active_job(active_job).tap do |job|
-          active_job.provider_job_id = job.id
-        end
+        SolidQueue::Job.enqueue(active_job)
       end
 
       def enqueue_at(active_job, timestamp) # :nodoc:
-        SolidQueue::Job.enqueue_active_job(active_job, scheduled_at: Time.at(timestamp)).tap do |job|
-          active_job.provider_job_id = job.id
-        end
+        SolidQueue::Job.enqueue(active_job, scheduled_at: Time.at(timestamp))
       end
 
       def enqueue_all(active_jobs) # :nodoc:
-        SolidQueue::Job.enqueue_all_active_jobs(active_jobs)
+        SolidQueue::Job.enqueue_all(active_jobs)
       end
     end
   end

--- a/lib/active_job/queue_adapters/solid_queue_adapter.rb
+++ b/lib/active_job/queue_adapters/solid_queue_adapter.rb
@@ -19,6 +19,10 @@ module ActiveJob
           active_job.provider_job_id = job.id
         end
       end
+
+      def enqueue_all(active_jobs) # :nodoc:
+        SolidQueue::Job.enqueue_active_jobs(active_jobs)
+      end
     end
   end
 end

--- a/test/models/solid_queue/job_test.rb
+++ b/test/models/solid_queue/job_test.rb
@@ -31,7 +31,7 @@ class SolidQueue::JobTest < ActiveSupport::TestCase
     active_job = AddToBufferJob.new(1).set(priority: 8, queue: "test")
 
     assert_ready do
-      SolidQueue::Job.enqueue_active_job(active_job)
+      SolidQueue::Job.enqueue(active_job)
     end
 
     solid_queue_job = SolidQueue::Job.last
@@ -51,7 +51,7 @@ class SolidQueue::JobTest < ActiveSupport::TestCase
     active_job = AddToBufferJob.new(1).set(priority: 8, queue: "test")
 
     assert_scheduled do
-      SolidQueue::Job.enqueue_active_job(active_job, scheduled_at: 5.minutes.from_now)
+      SolidQueue::Job.enqueue(active_job, scheduled_at: 5.minutes.from_now)
     end
 
     solid_queue_job = SolidQueue::Job.last

--- a/test/models/solid_queue/job_test.rb
+++ b/test/models/solid_queue/job_test.rb
@@ -65,7 +65,7 @@ class SolidQueue::JobTest < ActiveSupport::TestCase
     assert_equal solid_queue_job, execution.job
     assert_equal "test", execution.queue_name
     assert_equal 8, execution.priority
-    assert Time.now < execution.scheduled_at
+    assert_equal solid_queue_job.scheduled_at, execution.scheduled_at
   end
 
   test "enqueue jobs without concurrency controls" do

--- a/test/models/solid_queue/job_test.rb
+++ b/test/models/solid_queue/job_test.rb
@@ -35,6 +35,7 @@ class SolidQueue::JobTest < ActiveSupport::TestCase
     end
 
     solid_queue_job = SolidQueue::Job.last
+    assert_equal solid_queue_job.id, active_job.provider_job_id
     assert_equal 8, solid_queue_job.priority
     assert_equal "test", solid_queue_job.queue_name
     assert_equal "AddToBufferJob", solid_queue_job.class_name
@@ -118,6 +119,9 @@ class SolidQueue::JobTest < ActiveSupport::TestCase
     assert_multi(ready: 5, scheduled: 2, blocked: 2) do
       ActiveJob.perform_all_later(active_jobs)
     end
+
+    jobs = SolidQueue::Job.last(9)
+    assert_equal active_jobs.map(&:provider_job_id).sort, jobs.pluck(:id).sort
   end
 
   test "block jobs when concurrency limits are reached" do


### PR DESCRIPTION
This feature was introduced in Active Job in https://github.com/rails/rails/pull/46603. 

It wasn't properly supported until now in Solid Queue, as the adapter didn't respond to `#enqueue_all`, which means all jobs passed over to `perform_all_later` were enqueued one by one. With this pull request, we add proper support, minimizing the number of queries we have to perform. We still need to enqueue concurrency-limited jobs one by one, just like when moving them from `scheduled` to `ready`, but for scheduled jobs and ready-to-be-run jobs, we can insert these via `insert_all`.

With this implementation, everything is run within the same transaction and right now, there's no batching. All jobs passed to `enqueue_all` are inserted at once. This will be problematic if the batch is very large, causing problems with locking and with replica lag. However, this matches the behaviour of other adapters, leaving the batching up to the user of `perform_all_later`.  