### PR TITLE
Require Rails >= 7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     solid_queue (0.1.2)
-      rails (>= 7.0.3.1)
+      rails (>= 7.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ bundle exec rake solid_queue:start
 This will start processing jobs in all queues using the default configuration. See [below](#configuration) to learn more about configuring Solid Queue.
 
 ## Requirements
-Besides Rails 7, Solid Queue works best with MySQL 8+ or PostgreSQL 9.5+, as they support `FOR UPDATE SKIP LOCKED`. You can use it with older versions, but in that case, you might run into lock waits if you run multiple workers for the same queue.
+Besides Rails 7.1, Solid Queue works best with MySQL 8+ or PostgreSQL 9.5+, as they support `FOR UPDATE SKIP LOCKED`. You can use it with older versions, but in that case, you might run into lock waits if you run multiple workers for the same queue.
 
 ## Configuration
 

--- a/app/models/solid_queue/failed_execution.rb
+++ b/app/models/solid_queue/failed_execution.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 class SolidQueue::FailedExecution < SolidQueue::Execution
-  if Gem::Version.new(Rails.version) >= Gem::Version.new("7.1")
-    serialize :error, coder: JSON
-  else
-    serialize :error, JSON
-  end
+  serialize :error, coder: JSON
 
   before_create :expand_error_details_from_exception
 

--- a/app/models/solid_queue/job.rb
+++ b/app/models/solid_queue/job.rb
@@ -4,11 +4,7 @@ module SolidQueue
   class Job < Record
     include Executable
 
-    if Gem::Version.new(Rails.version) >= Gem::Version.new("7.1")
-      serialize :arguments, coder: JSON
-    else
-      serialize :arguments, JSON
-    end
+    serialize :arguments, coder: JSON
 
     class << self
       def enqueue_all(active_jobs)

--- a/solid_queue.gemspec
+++ b/solid_queue.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
-  spec.add_dependency "rails", ">= 7.0.3.1"
+  spec.add_dependency "rails", ">= 7.1"
   spec.add_development_dependency "debug"
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "puma"

--- a/test/integration/puma/plugin_test.rb
+++ b/test/integration/puma/plugin_test.rb
@@ -5,6 +5,8 @@ class PumaPluginTest < ActiveSupport::TestCase
   self.use_transactional_tests = false
 
   setup do
+    FileUtils.mkdir_p Rails.root.join("tmp", "pids")
+
     cmd = %w[
       bundle exec puma
         -b tcp://127.0.0.1:9222
@@ -22,7 +24,10 @@ class PumaPluginTest < ActiveSupport::TestCase
   end
 
   teardown do
-    Process.kill :INT, @pid
+    terminate_process(@pid, signal: :INT)
+    wait_for_registered_processes 0, timeout: 0.2.second
+
+    JobResult.delete_all
   end
 
   test "perform jobs inside puma's process" do


### PR DESCRIPTION
So we can simplify the calls to `serialize` for `Job` and `FailedExecution`. 