### PR TITLE
Fix small typo in job_attributes.rb

### DIFF
--- a/app/models/solid_queue/execution/job_attributes.rb
+++ b/app/models/solid_queue/execution/job_attributes.rb
@@ -6,23 +6,23 @@ module SolidQueue
       extend ActiveSupport::Concern
 
       included do
-        class_attribute :assumible_attributes_from_job, instance_accessor: false, default: %i[ queue_name priority ]
+        class_attribute :assumable_attributes_from_job, instance_accessor: false, default: %i[ queue_name priority ]
       end
 
       class_methods do
         def assumes_attributes_from_job(*attribute_names)
-          self.assumible_attributes_from_job |= attribute_names
+          self.assumable_attributes_from_job |= attribute_names
           before_create -> { assume_attributes_from_job }
         end
 
         def attributes_from_job(job)
-          job.attributes.symbolize_keys.slice(*assumible_attributes_from_job)
+          job.attributes.symbolize_keys.slice(*assumable_attributes_from_job)
         end
       end
 
       private
         def assume_attributes_from_job
-          self.class.assumible_attributes_from_job.each do |attribute|
+          self.class.assumable_attributes_from_job.each do |attribute|
             send("#{attribute}=", job.send(attribute))
           end
         end


### PR DESCRIPTION
Hi there and thanks for all the efforts on this great library!

I just started following this repository (recently started SolidQueue in my project and am very excited to deepen integration as cron-like tasks get supported in the near future), and as I was scanning some of the new code I noticed this small typo, so I figured I'd submit a quick PR to help a tiny bit. Simply changes `assumible` -> `assumable`.

Thanks again for the great work on this project!