### PR TITLE
Set `successfully_enqueued` for jobs enqueued in batch and return enqueued count

### DIFF
--- a/app/models/solid_queue/job.rb
+++ b/app/models/solid_queue/job.rb
@@ -15,9 +15,12 @@ module SolidQueue
           prepare_all_for_execution(jobs).tap do |enqueued_jobs|
             enqueued_jobs.each do |enqueued_job|
               active_jobs_by_job_id[enqueued_job.active_job_id].provider_job_id = enqueued_job.id
+              active_jobs_by_job_id[enqueued_job.active_job_id].successfully_enqueued = true
             end
           end
         end
+
+        active_jobs.count(&:successfully_enqueued?)
       end
 
       def enqueue(active_job, scheduled_at: Time.current)

--- a/test/models/solid_queue/job_test.rb
+++ b/test/models/solid_queue/job_test.rb
@@ -122,6 +122,7 @@ class SolidQueue::JobTest < ActiveSupport::TestCase
 
     jobs = SolidQueue::Job.last(9)
     assert_equal active_jobs.map(&:provider_job_id).sort, jobs.pluck(:id).sort
+    assert active_jobs.all?(&:successfully_enqueued?)
   end
 
   test "block jobs when concurrency limits are reached" do


### PR DESCRIPTION
Follow-up to https://github.com/basecamp/solid_queue/pull/93/

This is necessary so that the log subscriber doesn't crash. I had missed the pull request https://github.com/rails/rails/pull/47844, merged after the original `perform_all_later` feature was added to Active Job.