### PR TITLE
Fix config.yml template indentation

### DIFF
--- a/lib/generators/solid_queue/install/templates/config.yml
+++ b/lib/generators/solid_queue/install/templates/config.yml
@@ -1,4 +1,4 @@
-#default: &default
+# default: &default
 #   dispatchers:
 #     - polling_interval: 1
 #       batch_size: 500


### PR DESCRIPTION
Prior to this change, if all #'s are removed from the config template you're left with is a yaml file that solid_queue can't parse.

```
bundle exec rake solid_queue:start
rake aborted!
YAML syntax error occurred while parsing
/project/config/solid_queue.yml. Please note
that YAML must be consistently indented using spaces. Tabs are not
allowed. Error: (<unknown>): did not find expected key while parsing a
block mapping at line 1 column 1
```

reproducable in this repo via (remove comments first).  After fix:

```
ActiveSupport::ConfigurationFile.parse("./lib/generators/solid_queue/install/templates/config.yml")["development"]
=> {"batch_size"=>10, "dispatchers"=>[{"polling_interval"=>1,
"batch_size"=>500}], "workers"=>[{"queues"=>"*", "threads"=>5,
"processes"=>1, "polling_interval"=>0.1}]}
```