### PR TITLE
Ensure 60.seconds et al. works out-of-the-box

### DIFF
--- a/lib/solid_queue.rb
+++ b/lib/solid_queue.rb
@@ -6,6 +6,9 @@ require "solid_queue/engine"
 require "active_job/queue_adapters/solid_queue_adapter"
 require "active_job/concurrency_controls"
 
+require "active_support/deprecator"
+require "active_support/core_ext/numeric/time"
+
 require "solid_queue/app_executor"
 require "solid_queue/processes/supervised"
 require "solid_queue/processes/registrable"


### PR DESCRIPTION
I was preparing a reproducible bug report for a separate issue, but couldn't get the script to run as I was always hit with a `NoMethodError` on the `60.seconds` call in the `mattr_accessor`.