### PR TITLE
Don't go through the general dispatch flow when releasing claimed executions

### DIFF
--- a/app/models/solid_queue/claimed_execution.rb
+++ b/app/models/solid_queue/claimed_execution.rb
@@ -39,7 +39,7 @@ class SolidQueue::ClaimedExecution < SolidQueue::Execution
 
   def release
     transaction do
-      job.prepare_for_execution
+      job.dispatch_bypassing_concurrency_limits
       destroy!
     end
   end

--- a/app/models/solid_queue/job/executable.rb
+++ b/app/models/solid_queue/job/executable.rb
@@ -73,6 +73,10 @@ module SolidQueue
         end
       end
 
+      def dispatch_bypassing_concurrency_limits
+        ready
+      end
+
       def finished!
         if preserve_finished_jobs?
           touch(:finished_at)

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -51,4 +51,6 @@ Rails.application.configure do
   logger = ActiveSupport::Logger.new(STDOUT)
   config.solid_queue.on_thread_error = ->(exception) { logger.error("#{exception.class.name}: #{exception.message}\n#{exception.backtrace.join("\n")}") }
   config.solid_queue.logger = ActiveSupport::Logger.new(nil)
+
+  config.solid_queue.shutdown_timeout = 2.seconds
 end


### PR DESCRIPTION
That's it, don't try to gain the concurrency lock, because claimed executions with concurrency limits that are released would most likely be holding the semaphore themselves, as it's released after completing. This means these claimed executions would go to _blocked_ upon release, leaving the semaphore busy. Just assume that if a job has a claimed execution, it's because it already gained the lock when going to _ready_.