### PR TITLE
Clear clearable jobs in a loop instead of batching

### DIFF
--- a/app/models/solid_queue/job/clearable.rb
+++ b/app/models/solid_queue/job/clearable.rb
@@ -11,7 +11,10 @@ module SolidQueue
 
       class_methods do
         def clear_finished_in_batches(batch_size: 500, finished_before: SolidQueue.clear_finished_jobs_after.ago)
-          clearable(finished_before: finished_before).in_batches(of: batch_size).delete_all
+          loop do
+            records_deleted = clearable(finished_before: finished_before).limit(batch_size).delete_all
+            break if records_deleted == 0
+          end
         end
       end
     end


### PR DESCRIPTION
ActiveRecord batching can be slow when looping over records filtered by non-PKs. We don't care about the order of deletion here, so we can just use a loop to delete the clearable jobs; this allows us to achieve better performance in general.

/cc @rosa @djmb 