### PR TITLE
Implement retry_all and discard_all

### DIFF
--- a/app/models/solid_queue/claimed_execution.rb
+++ b/app/models/solid_queue/claimed_execution.rb
@@ -23,6 +23,10 @@ class SolidQueue::ClaimedExecution < SolidQueue::Execution
     def release_all
       includes(:job).each(&:release)
     end
+
+    def discard_all(*)
+      raise UndiscardableError, "Can't discard jobs in progress"
+    end
   end
 
   def perform

--- a/app/models/solid_queue/claimed_execution.rb
+++ b/app/models/solid_queue/claimed_execution.rb
@@ -24,7 +24,11 @@ class SolidQueue::ClaimedExecution < SolidQueue::Execution
       includes(:job).each(&:release)
     end
 
-    def discard_all(*)
+    def discard_all_in_batches(*)
+      raise UndiscardableError, "Can't discard jobs in progress"
+    end
+
+    def discard_all_from_jobs(*)
       raise UndiscardableError, "Can't discard jobs in progress"
     end
   end

--- a/app/models/solid_queue/execution/dispatching.rb
+++ b/app/models/solid_queue/execution/dispatching.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module SolidQueue
+  class Execution
+    module Dispatching
+      extend ActiveSupport::Concern
+
+      class_methods do
+        def dispatch_batch(job_ids)
+          jobs = Job.where(id: job_ids)
+
+          Job.dispatch_all(jobs).map(&:id).tap do |dispatched_job_ids|
+            where(job_id: dispatched_job_ids).delete_all
+            SolidQueue.logger.info("[SolidQueue] Dispatched scheduled batch with #{dispatched_job_ids.size} jobs")
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/solid_queue/execution/dispatching.rb
+++ b/app/models/solid_queue/execution/dispatching.rb
@@ -6,12 +6,12 @@ module SolidQueue
       extend ActiveSupport::Concern
 
       class_methods do
-        def dispatch_batch(job_ids)
+        def dispatch_jobs(job_ids)
           jobs = Job.where(id: job_ids)
 
           Job.dispatch_all(jobs).map(&:id).tap do |dispatched_job_ids|
             where(job_id: dispatched_job_ids).delete_all
-            SolidQueue.logger.info("[SolidQueue] Dispatched scheduled batch with #{dispatched_job_ids.size} jobs")
+            SolidQueue.logger.info("[SolidQueue] Dispatched #{dispatched_job_ids.size} jobs")
           end
         end
       end

--- a/app/models/solid_queue/failed_execution.rb
+++ b/app/models/solid_queue/failed_execution.rb
@@ -1,27 +1,40 @@
 # frozen_string_literal: true
 
-class SolidQueue::FailedExecution < SolidQueue::Execution
-  serialize :error, coder: JSON
+module SolidQueue
+  class FailedExecution < Execution
+    include Dispatching
 
-  before_create :expand_error_details_from_exception
+    serialize :error, coder: JSON
 
-  attr_accessor :exception
+    before_create :expand_error_details_from_exception
 
-  def retry
-    transaction do
-      job.prepare_for_execution
-      destroy!
+    attr_accessor :exception
+
+    class << self
+      def retry_all(jobs)
+        transaction do
+          retriable_job_ids = where(job_id: jobs.map(&:id)).order(:job_id).lock.pluck(:job_id)
+          dispatch_batch(retriable_job_ids)
+        end
+      end
     end
-  end
 
-  %i[ exception_class message backtrace ].each do |attribute|
-    define_method(attribute) { error.with_indifferent_access[attribute] }
-  end
+    def retry
+      with_lock do
+        job.prepare_for_execution
+        destroy!
+      end
+    end
 
-  private
-    def expand_error_details_from_exception
-      if exception
-        self.error = { exception_class: exception.class.name, message: exception.message, backtrace: exception.backtrace }
+    %i[ exception_class message backtrace ].each do |attribute|
+      define_method(attribute) { error.with_indifferent_access[attribute] }
+    end
+
+    private
+      def expand_error_details_from_exception
+        if exception
+          self.error = { exception_class: exception.class.name, message: exception.message, backtrace: exception.backtrace }
+        end
       end
     end
 end

--- a/app/models/solid_queue/failed_execution.rb
+++ b/app/models/solid_queue/failed_execution.rb
@@ -10,12 +10,9 @@ module SolidQueue
 
     attr_accessor :exception
 
-    class << self
-      def retry_all(jobs)
-        transaction do
-          retriable_job_ids = where(job_id: jobs.map(&:id)).order(:job_id).lock.pluck(:job_id)
-          dispatch_batch(retriable_job_ids)
-        end
+    def self.retry_all(jobs)
+      transaction do
+        dispatch_jobs lock_all_from_jobs(jobs)
       end
     end
 

--- a/app/models/solid_queue/job/concurrency_controls.rb
+++ b/app/models/solid_queue/job/concurrency_controls.rb
@@ -13,6 +13,12 @@ module SolidQueue
         before_destroy :unblock_next_blocked_job, if: -> { concurrency_limited? && ready? }
       end
 
+      class_methods do
+        def release_all_concurrency_locks(jobs)
+          Semaphore.signal_all(jobs.select(&:concurrency_limited?))
+        end
+      end
+
       def unblock_next_blocked_job
         if release_concurrency_lock
           release_next_blocked_job

--- a/app/models/solid_queue/job/executable.rb
+++ b/app/models/solid_queue/job/executable.rb
@@ -94,7 +94,7 @@ module SolidQueue
       end
 
       def discard
-        execution.discard
+        execution&.discard
       end
 
       def failed_with(exception)

--- a/app/models/solid_queue/queue.rb
+++ b/app/models/solid_queue/queue.rb
@@ -33,7 +33,7 @@ module SolidQueue
     end
 
     def clear
-      Job.where(queue_name: name).each(&:discard)
+      ReadyExecution.queued_as(name).discard_all_in_batches
     end
 
     def size

--- a/app/models/solid_queue/ready_execution.rb
+++ b/app/models/solid_queue/ready_execution.rb
@@ -41,12 +41,5 @@ module SolidQueue
           end
         end
     end
-
-    def discard
-      with_lock do
-        job.destroy
-        destroy
-      end
-    end
   end
 end

--- a/app/models/solid_queue/ready_execution.rb
+++ b/app/models/solid_queue/ready_execution.rb
@@ -40,6 +40,12 @@ module SolidQueue
             where(job_id: claimed.pluck(:job_id)).delete_all
           end
         end
+
+
+        def discard_jobs(job_ids)
+          Job.release_all_concurrency_locks Job.where(id: job_ids)
+          super
+        end
     end
   end
 end

--- a/app/models/solid_queue/scheduled_execution.rb
+++ b/app/models/solid_queue/scheduled_execution.rb
@@ -16,7 +16,7 @@ module SolidQueue
           job_ids = next_batch(batch_size).non_blocking_lock.pluck(:job_id)
           if job_ids.empty? then []
           else
-            dispatch_batch(job_ids)
+            dispatch_jobs(job_ids)
           end
         end
       end

--- a/app/models/solid_queue/semaphore.rb
+++ b/app/models/solid_queue/semaphore.rb
@@ -13,9 +13,17 @@ module SolidQueue
       def signal(job)
         Proxy.new(job).signal
       end
+
+      def signal_all(jobs)
+        Proxy.signal_all(jobs)
+      end
     end
 
     class Proxy
+      def self.signal_all(jobs)
+        Semaphore.where(key: jobs.map(&:concurrency_key)).update_all("value = value + 1")
+      end
+
       def initialize(job)
         @job = job
         @retries = 0

--- a/test/dummy/app/jobs/raising_job.rb
+++ b/test/dummy/app/jobs/raising_job.rb
@@ -1,16 +1,17 @@
-class DefaultsError < StandardError; end
-class DiscardableError < StandardError; end
-
 class RaisingJob < ApplicationJob
+  class DefaultError < StandardError; end
+  class DiscardableError < StandardError; end
+
   queue_as :background
 
-  retry_on DefaultsError
+  retry_on DefaultError, attempts: 3, wait: 0.1.seconds
   discard_on DiscardableError
 
-  def perform(raising, attempts, *)
+  def perform(raising, identifier, attempts = 1)
     raising = raising.shift if raising.is_a?(Array)
-    if raising && executions < attempts
-      JobBuffer.add("Raised #{raising} for the #{executions.ordinalize} time")
+
+    if raising && executions <= attempts
+      JobBuffer.add("#{identifier}: raised #{raising} for the #{executions.ordinalize} time")
       raise raising, "This is a #{raising} exception"
     else
       JobBuffer.add("Successfully completed job")

--- a/test/integration/jobs_lifecycle_test.rb
+++ b/test/integration/jobs_lifecycle_test.rb
@@ -3,8 +3,8 @@ require "test_helper"
 
 class JobsLifecycleTest < ActiveSupport::TestCase
   setup do
-    @worker = SolidQueue::Worker.new(queues: "background", threads: 3, polling_interval: 0.5)
-    @dispatcher = SolidQueue::Dispatcher.new(batch_size: 10, polling_interval: 1)
+    @worker = SolidQueue::Worker.new(queues: "background", threads: 3)
+    @dispatcher = SolidQueue::Dispatcher.new(batch_size: 10, polling_interval: 0.2)
   end
 
   teardown do

--- a/test/integration/jobs_lifecycle_test.rb
+++ b/test/integration/jobs_lifecycle_test.rb
@@ -27,6 +27,54 @@ class JobsLifecycleTest < ActiveSupport::TestCase
     assert_equal 2, SolidQueue::Job.finished.count
   end
 
+  test "enqueue and run jobs that fail without retries" do
+    RaisingJob.perform_later(RuntimeError, "A")
+    RaisingJob.perform_later(RuntimeError, "B")
+    jobs = SolidQueue::Job.last(2)
+
+    @dispatcher.start
+    @worker.start
+
+    wait_for_jobs_to_finish_for(3.seconds)
+
+    message = "raised RuntimeError for the 1st time"
+    assert_equal [ "A: #{message}", "B: #{message}" ], JobBuffer.values.sort
+
+    assert_empty SolidQueue::Job.finished
+  end
+
+  test "enqueue and run jobs that fail and succeed after retrying" do
+    RaisingJob.perform_later(RaisingJob::DefaultError, "A", 5) # this will fail after being retried
+    RaisingJob.perform_later(RaisingJob::DefaultError, "B")
+
+    @dispatcher.start
+    @worker.start
+
+    wait_for_jobs_to_finish_for(3.seconds)
+
+    messages_from_a = 1.upto(3).collect { |i| "A: raised RaisingJob::DefaultError for the #{i.ordinalize} time" }
+    messages_from_b = [ "B: raised RaisingJob::DefaultError for the 1st time", "Successfully completed job" ]
+
+    assert_equal messages_from_a + messages_from_b, JobBuffer.values.sort
+
+    assert_equal 4, SolidQueue::Job.finished.count # B + its retry + 2 retries of A
+    assert_equal 1, SolidQueue::FailedExecution.count
+  end
+
+  test "enqueue and run jobs that fail and it's discarded" do
+    RaisingJob.perform_later(RaisingJob::DiscardableError, "A")
+
+    @dispatcher.start
+    @worker.start
+
+    wait_for_jobs_to_finish_for(1.seconds)
+
+    assert_equal [ "A: raised RaisingJob::DiscardableError for the 1st time" ], JobBuffer.values.sort
+
+    assert_equal 1, SolidQueue::Job.finished.count
+    assert_equal 0, SolidQueue::FailedExecution.count
+  end
+
   test "schedule and run jobs" do
     AddToBufferJob.set(wait: 1.day).perform_later("I'm scheduled")
     AddToBufferJob.set(wait: 3.days).perform_later("I'm scheduled later")

--- a/test/models/solid_queue/claimed_execution_test.rb
+++ b/test/models/solid_queue/claimed_execution_test.rb
@@ -18,7 +18,7 @@ class SolidQueue::ClaimedExecutionTest < ActiveSupport::TestCase
   end
 
   test "perform job that fails" do
-    claimed_execution = prepare_and_claim_job RaisingJob.perform_later(RuntimeError, 2)
+    claimed_execution = prepare_and_claim_job RaisingJob.perform_later(RuntimeError, "A")
     job = claimed_execution.job
 
     assert_difference -> { SolidQueue::ClaimedExecution.count } => -1, -> { SolidQueue::FailedExecution.count } => 1 do
@@ -38,7 +38,7 @@ class SolidQueue::ClaimedExecutionTest < ActiveSupport::TestCase
     subscriber = ErrorBuffer.new
 
     with_error_subscriber(subscriber) do
-      claimed_execution = prepare_and_claim_job RaisingJob.perform_later(RuntimeError, 2)
+      claimed_execution = prepare_and_claim_job RaisingJob.perform_later(RuntimeError, "B")
 
       claimed_execution.perform
     end

--- a/test/models/solid_queue/failed_execution_test.rb
+++ b/test/models/solid_queue/failed_execution_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class SolidQueue::FailedExecutionTest < ActiveSupport::TestCase
+  setup do
+    @worker = SolidQueue::Worker.new(queues: "background")
+    @worker.mode = :inline
+  end
+
+  test "run job that fails" do
+    RaisingJob.perform_later(RuntimeError, "A")
+    @worker.start
+
+    assert_equal 1, SolidQueue::FailedExecution.count
+    assert SolidQueue::Job.last.failed?
+  end
+
+  test "retry failed job" do
+    RaisingJob.perform_later(RuntimeError, "A")
+    @worker.start
+
+    assert_difference -> { SolidQueue::FailedExecution.count }, -1 do
+      assert_difference -> { SolidQueue::ReadyExecution.count }, +1 do
+        SolidQueue::FailedExecution.last.retry
+      end
+    end
+  end
+
+  test "retry failed jobs in bulk" do
+    1.upto(5) { |i| RaisingJob.perform_later(RuntimeError, i) }
+    1.upto(3) { |i| AddToBufferJob.perform_later(i) }
+
+    @worker.start
+
+    assert_difference -> { SolidQueue::FailedExecution.count }, -5 do
+      assert_difference -> { SolidQueue::ReadyExecution.count }, +5 do
+        SolidQueue::FailedExecution.retry_all(SolidQueue::Job.all)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- `retry_all` is implemented by selecting failed executions, locking them, dispatching their jobs and deleting them. 
This is very similar to the work we have to do when dispatching scheduled executions, so this extracts that common functionality into its own concern.

- `discard_all` makes some concessions. It's intended to be used in very specific, emergency situations, so that's ok. First, it starts from the execution records, as we need to lock them before the jobs to avoid jobs changing state while they're being discarded. Because of this, we can only discard jobs in the same state together in the same batch. Then, when discarding ready executions that are concurrency-limited, we need to unblock the next jobs. Since we're aiming for performance here and this is not to be used in regular operation, but in exceptional circumstances, let's just signal all applicable semaphores and let the concurrency maintenance task take care of blocked executions.