### PR TITLE
Expose `SolidQueue::Job#status`

### DIFF
--- a/app/models/solid_queue/job/executable.rb
+++ b/app/models/solid_queue/job/executable.rb
@@ -89,6 +89,14 @@ module SolidQueue
         finished_at.present?
       end
 
+      def status
+        if finished?
+          :finished
+        elsif execution.present?
+          execution.model_name.element.sub("_execution", "").to_sym
+        end
+      end
+
       def retry
         failed_execution&.retry
       end

--- a/app/models/solid_queue/job/schedulable.rb
+++ b/app/models/solid_queue/job/schedulable.rb
@@ -31,6 +31,10 @@ module SolidQueue
         scheduled_at.nil? || scheduled_at <= Time.current
       end
 
+      def scheduled?
+        scheduled_execution.present?
+      end
+
       private
         def schedule
           ScheduledExecution.create_or_find_by!(job_id: id)

--- a/test/models/solid_queue/job_test.rb
+++ b/test/models/solid_queue/job_test.rb
@@ -35,6 +35,8 @@ class SolidQueue::JobTest < ActiveSupport::TestCase
     end
 
     solid_queue_job = SolidQueue::Job.last
+    assert solid_queue_job.ready?
+    assert_equal :ready, solid_queue_job.status
     assert_equal solid_queue_job.id, active_job.provider_job_id
     assert_equal 8, solid_queue_job.priority
     assert_equal "test", solid_queue_job.queue_name
@@ -56,6 +58,8 @@ class SolidQueue::JobTest < ActiveSupport::TestCase
     end
 
     solid_queue_job = SolidQueue::Job.last
+    assert solid_queue_job.scheduled?
+    assert_equal :scheduled, solid_queue_job.status
     assert_equal 8, solid_queue_job.priority
     assert_equal "test", solid_queue_job.queue_name
     assert_equal "AddToBufferJob", solid_queue_job.class_name


### PR DESCRIPTION
This is prone to race conditions and stale reads, and it's just intended for use in Mission Control or other reporting tools, not for regular operation.