### PR TITLE
Fix encoding error in sqlite

### DIFF
--- a/lib/solid_queue/processes/registrable.rb
+++ b/lib/solid_queue/processes/registrable.rb
@@ -55,7 +55,7 @@ module SolidQueue::Processes
       end
 
       def hostname
-        @hostname ||= Socket.gethostname
+        @hostname ||= Socket.gethostname.force_encoding(Encoding::UTF_8)
       end
 
       def process_pid

--- a/test/models/solid_queue/process_test.rb
+++ b/test/models/solid_queue/process_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "minitest/mock"
 
 class SolidQueue::ProcessTest < ActiveSupport::TestCase
   test "prune processes with expired heartbeats" do
@@ -11,6 +12,17 @@ class SolidQueue::ProcessTest < ActiveSupport::TestCase
 
     assert_difference -> { SolidQueue::Process.count }, -2 do
       SolidQueue::Process.prune
+    end
+  end
+
+  test "hostname's with special characters are properly loaded" do
+    worker = SolidQueue::Worker.new(queues: "*", threads: 3, polling_interval: 0.2)
+    hostname = "Basecamp’s-Computer"
+
+    Socket.stub :gethostname, hostname.force_encoding("ASCII-8BIT") do
+      worker.start
+      wait_for_registered_processes(1, timeout: 1.second)
+      assert_equal hostname, SolidQueue::Process.last.hostname
     end
   end
 end


### PR DESCRIPTION
When `Socket.gethostname` returns a hostname with a special character like apostrophe in `Basecamp’s-Computer`, an encoding error is raised `Encoding::UndefinedConversionError: "\xE2" from ASCII-8BIT to UTF-8`.

By forcing a utf-8 encoding, the error goes away and the process row properly inserts.

A similar issue occurred in the newrelic ruby gem, and required the same solution https://github.com/newrelic/newrelic-ruby-agent/commit/e1f65a830909adca5021f1d0f0c14b399579b7c8