### PR TITLE
improve memory usage for releasable concurrency keys

### DIFF
--- a/app/models/solid_queue/blocked_execution.rb
+++ b/app/models/solid_queue/blocked_execution.rb
@@ -30,10 +30,10 @@ module SolidQueue
 
       private
         def releasable(concurrency_keys)
-          semaphores = Semaphore.where(key: concurrency_keys).select(:key, :value).index_by(&:key)
+          semaphores = Semaphore.where(key: concurrency_keys).pluck(:key, :value).to_h
 
           # Concurrency keys without semaphore + concurrency keys with open semaphore
-          (concurrency_keys - semaphores.keys) | semaphores.select { |key, semaphore| semaphore.value > 0 }.map(&:first)
+          (concurrency_keys - semaphores.keys) | semaphores.select { |_key, value| value > 0 }.keys
         end
     end
 


### PR DESCRIPTION
**Detail**

Improve memory usage

**Additional information**

Benchmark script:
```ruby
require "benchmark/ips"
require "benchmark/memory"

def releasable(concurrency_keys)
  semaphores = SolidQueue::Semaphore.where(key: concurrency_keys).select(:key, :value).index_by(&:key)

  # Concurrency keys without semaphore + concurrency keys with open semaphore
  (concurrency_keys - semaphores.keys) | semaphores.select { |key, semaphore| semaphore.value > 0 }.map(&:first)
end

def refactored_releasable(concurrency_keys)
  semaphores = SolidQueue::Semaphore.where(key: concurrency_keys).pluck(:key, :value).to_h

  # Concurrency keys without semaphore + concurrency keys with open semaphore
  (concurrency_keys - semaphores.keys) | semaphores.select { |_key, value| value > 0 }.keys
end

def concurrency_keys
  ('a'..'z').to_a
end

def seed
  SolidQueue::Semaphore.where(key: concurrency_keys).delete_all
  concurrency_keys.each_with_index do |key, i|
    SolidQueue::Semaphore.create(key: key, value: i, expires_at: 5.minutes.since)
  end
end

Benchmark.memory do |x|
  seed
  x.report("original") do
    releasable(concurrency_keys)
  end
  
  seed
  x.report("refactored") do
    refactored_releasable(concurrency_keys)
  end
end

Benchmark.ips do |x|
  seed
  x.report("original") do
    releasable(concurrency_keys)
  end
  
  seed
  x.report("refactored") do
    refactored_releasable(concurrency_keys)
  end
end
```
Benchmark result:
```
Calculating -------------------------------------
            original    44.648k memsize (     2.592k retained)
                       458.000  objects (    16.000  retained)
                        50.000  strings (     2.000  retained)
          refactored    20.896k memsize (     2.128k retained)
                       278.000  objects (    11.000  retained)
                        50.000  strings (     4.000  retained)

Warming up --------------------------------------
            original   105.000 i/100ms
          refactored   301.000 i/100ms
Calculating -------------------------------------
            original      2.137k (±35.4%) i/s -      7.350k in   5.084206s
          refactored    609.056 (±27.3%) i/s -      3.010k in   5.199923s
```