### PR TITLE
Include job_id in order clause when fetching scheduled jobs to dispatch and when dispatching

### DIFF
--- a/app/models/solid_queue/execution/dispatching.rb
+++ b/app/models/solid_queue/execution/dispatching.rb
@@ -10,7 +10,7 @@ module SolidQueue
           jobs = Job.where(id: job_ids)
 
           Job.dispatch_all(jobs).map(&:id).tap do |dispatched_job_ids|
-            where(job_id: dispatched_job_ids).delete_all
+            where(job_id: dispatched_job_ids).order(:job_id).delete_all
             SolidQueue.logger.info("[SolidQueue] Dispatched #{dispatched_job_ids.size} jobs")
           end
         end

--- a/app/models/solid_queue/scheduled_execution.rb
+++ b/app/models/solid_queue/scheduled_execution.rb
@@ -5,7 +5,7 @@ module SolidQueue
     include Dispatching
 
     scope :due, -> { where(scheduled_at: ..Time.current) }
-    scope :ordered, -> { order(scheduled_at: :asc, priority: :asc) }
+    scope :ordered, -> { order(scheduled_at: :asc, priority: :asc, job_id: :asc) }
     scope :next_batch, ->(batch_size) { due.ordered.limit(batch_size) }
 
     assumes_attributes_from_job :scheduled_at

--- a/test/unit/dispatcher_test.rb
+++ b/test/unit/dispatcher_test.rb
@@ -4,6 +4,8 @@ require "active_support/testing/method_call_assertions"
 class DispatcherTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::MethodCallAssertions
 
+  self.use_transactional_tests = false
+
   setup do
     @dispatcher = SolidQueue::Dispatcher.new(polling_interval: 0.1, batch_size: 10)
   end
@@ -56,6 +58,7 @@ class DispatcherTest < ActiveSupport::TestCase
     assert_equal 15, SolidQueue::ScheduledExecution.count
 
     another_dispatcher = SolidQueue::Dispatcher.new(polling_interval: 0.1, batch_size: 10)
+
     @dispatcher.start
     another_dispatcher.start
 


### PR DESCRIPTION
This was missing and makes the locking prone to deadlocks when we have a bunch of jobs scheduled at the same time with the same priority, since we'd have a non-deterministic ordering.

Besides, on the `DELETE` query, force `ORDER BY job_id` even if we don't care about that. It turns out, under certain circumstances, when the scheduled_executions table is too small, MySQL might choose not to use any indexes for the `DELETE` by `job_id`. This means it might lock other rows besides those it's going to delete. Then, when running more than one dispatcher doing this, we might end up with a deadlock because one dispatcher is deleting and locking some rows that is not going to delete, and the other is doing the same, and both are waiting for the other's lock.

This deadlock was happening consistently in CI, for MySQL only, but I didn't manage to reproduce it locally, and it has never happened in production for us. Using an `INDEX` hint in the `DELETE` query, to ensure the index on `job_id` was used, also avoided the deadlock.