### PR TITLE
Add option to limit clearing of jobs to specific class name(s)

### DIFF
--- a/app/models/solid_queue/job/clearable.rb
+++ b/app/models/solid_queue/job/clearable.rb
@@ -6,13 +6,13 @@ module SolidQueue
       extend ActiveSupport::Concern
 
       included do
-        scope :clearable, ->(finished_before: SolidQueue.clear_finished_jobs_after.ago) { where.not(finished_at: nil).where(finished_at: ...finished_before) }
+        scope :clearable, ->(finished_before: SolidQueue.clear_finished_jobs_after.ago, class_name: nil) { where.not(finished_at: nil).where(finished_at: ...finished_before).where(class_name.present? ? { class_name: class_name } : {}) }
       end
 
       class_methods do
-        def clear_finished_in_batches(batch_size: 500, finished_before: SolidQueue.clear_finished_jobs_after.ago)
+        def clear_finished_in_batches(batch_size: 500, finished_before: SolidQueue.clear_finished_jobs_after.ago, class_name: nil)
           loop do
-            records_deleted = clearable(finished_before: finished_before).limit(batch_size).delete_all
+            records_deleted = clearable(finished_before: finished_before, class_name: class_name).limit(batch_size).delete_all
             break if records_deleted == 0
           end
         end


### PR DESCRIPTION
I'll give this a try. Please let me know if it could be improved.

This is a suggestion originating from https://github.com/basecamp/solid_queue/pull/155#issuecomment-1979577345 to add a `class_name:` option to `clear_finished_in_batches`.

Instead of exposing new configuration settings to Solid Queue for controlling the expiry of specific jobs this PR would enable anyone to write their own custom cleanup logic and still rely on the core cleanup functionality.