### PR TITLE
Change number of threads per worker by default to 3 instead of 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Everything is optional. If no configuration is provided, Solid Queue will run wi
   This will create a worker fetching jobs from all queues starting with `staging`. The wildcard `*` is only allowed on its own or at the end of a queue name; you can't specify queue names such as `*_some_queue`. These will be ignored.
 
   Finally, you can combine prefixes with exact names, like `[ staging*, background ]`, and the behaviour with respect to order will be the same as with only exact names.
-- `threads`: this is the max size of the thread pool that each worker will have to run jobs. Each worker will fetch this number of jobs from their queue(s), at most and will post them to the thread pool to be run. By default, this is `5`. Only workers have this setting.
+- `threads`: this is the max size of the thread pool that each worker will have to run jobs. Each worker will fetch this number of jobs from their queue(s), at most and will post them to the thread pool to be run. By default, this is `3`. Only workers have this setting.
 - `processes`: this is the number of worker processes that will be forked by the supervisor with the settings given. By default, this is `1`, just a single process. This setting is useful if you want to dedicate more than one CPU core to a queue or queues with the same configuration. Only workers have this setting.
 
 

--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -4,7 +4,7 @@ module SolidQueue
   class Configuration
     WORKER_DEFAULTS = {
       queues: "*",
-      threads: 5,
+      threads: 3,
       processes: 1,
       polling_interval: 0.1
     }


### PR DESCRIPTION
Related to #137