### PR TITLE
Handle nil logger situation

### DIFF
--- a/lib/solid_queue/processes/poller.rb
+++ b/lib/solid_queue/processes/poller.rb
@@ -39,7 +39,7 @@ module SolidQueue::Processes
 
       def with_polling_volume
         if SolidQueue.silence_polling?
-          ActiveRecord::Base.logger.silence { yield }
+          ActiveRecord::Base.logger&.silence { yield }
         else
           yield
         end


### PR DESCRIPTION
There are times when ActiveRecord::Base.logger is set to nil and solid_queue should handle those times gracefully.