### PR TITLE
option for silencing logging for heartbeats

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ There are several settings that control how Solid Queue works that you can set a
 - `process_alive_threshold`: how long to wait until a process is considered dead after its last heartbeat—defaults to 5 minutes.
 - `shutdown_timeout`: time the supervisor will wait since it sent the `TERM` signal to its supervised processes before sending a `QUIT` version to them requesting immediate termination—defaults to 5 seconds.
 - `silence_polling`: whether to silence Active Record logs emitted when polling for both workers and dispatchers—defaults to `true`.
+- `silence_heartbeats`: whether to silence Active Record logs emitted for heartbeats for both workers and dispatchers—defaults to `false`.
 - `supervisor_pidfile`: path to a pidfile that the supervisor will create when booting to prevent running more than one supervisor in the same host, or in case you want to use it for a health check. It's `nil` by default.
 - `preserve_finished_jobs`: whether to keep finished jobs in the `solid_queue_jobs` table—defaults to `true`.
 - `clear_finished_jobs_after`: period to keep finished jobs around, in case `preserve_finished_jobs` is true—defaults to 1 day. **Note:** Right now, there's no automatic cleanup of finished jobs. You'd need to do this by periodically invoking `SolidQueue::Job.clear_finished_in_batches`, but this will happen automatically in the near future.

--- a/lib/solid_queue.rb
+++ b/lib/solid_queue.rb
@@ -33,6 +33,7 @@ module SolidQueue
   mattr_accessor :shutdown_timeout, default: 5.seconds
 
   mattr_accessor :silence_polling, default: true
+  mattr_accessor :silence_heartbeats, default: false
 
   mattr_accessor :supervisor_pidfile
   mattr_accessor :supervisor, default: false
@@ -57,6 +58,10 @@ module SolidQueue
 
   def silence_polling?
     silence_polling
+  end
+
+  def silence_heartbeats?
+    silence_heartbeats
   end
 
   def preserve_finished_jobs?


### PR DESCRIPTION
In development, and possible other environments, it's sometimes nice to not see the heartbeat logging. This adds an option to silence the logging for heartbeats. It's very similar to the "silence_polling" option.

Usage:

```
  config.solid_queue.silence_heartbeats = true
```

