### PR TITLE
Make concurrency tests less flaky

### DIFF
--- a/test/dummy/app/jobs/non_overlapping_update_result_job.rb
+++ b/test/dummy/app/jobs/non_overlapping_update_result_job.rb
@@ -1,3 +1,3 @@
-class SequentialUpdateResultJob < UpdateResultJob
+class NonOverlappingUpdateResultJob < UpdateResultJob
   limits_concurrency key: ->(job_result, **) { job_result }
 end

--- a/test/dummy/app/jobs/update_result_job.rb
+++ b/test/dummy/app/jobs/update_result_job.rb
@@ -1,5 +1,6 @@
 class UpdateResultJob < ApplicationJob
   def perform(job_result, name:, pause: nil, exception: nil)
+    job_result.status += " + " unless job_result.status.blank?
     job_result.status += "s#{name}"
 
     sleep(pause) if pause

--- a/test/integration/instrumentation_test.rb
+++ b/test/integration/instrumentation_test.rb
@@ -234,7 +234,7 @@ class InstrumentationTest < ActiveSupport::TestCase
     5.times { AddToBufferJob.perform_later("A") }
     # 1 ready + 3 blocked
     result = JobResult.create!
-    4.times { SequentialUpdateResultJob.perform_later(result, name: "A") }
+    4.times { NonOverlappingUpdateResultJob.perform_later(result, name: "A") }
 
     events = subscribed("discard_all.solid_queue") do
       SolidQueue::ReadyExecution.discard_all_from_jobs(SolidQueue::Job.all)
@@ -261,7 +261,7 @@ class InstrumentationTest < ActiveSupport::TestCase
   test "unblocking job emits release_blocked event" do
     result = JobResult.create!
     # 1 ready, 2 blocked
-    3.times { SequentialUpdateResultJob.perform_later(result, name: "A") }
+    3.times { NonOverlappingUpdateResultJob.perform_later(result, name: "A") }
 
     # Simulate expiry of the concurrency locks
     travel_to 3.days.from_now
@@ -283,11 +283,11 @@ class InstrumentationTest < ActiveSupport::TestCase
   test "unblocking jobs in bulk emits release_many_blocked event" do
     result = JobResult.create!
     # 1 ready, 3 blocked
-    4.times { SequentialUpdateResultJob.perform_later(result, name: "A") }
+    4.times { NonOverlappingUpdateResultJob.perform_later(result, name: "A") }
 
     # 1 ready, 2 blocked
     result = JobResult.create!
-    3.times { SequentialUpdateResultJob.perform_later(result, name: "B") }
+    3.times { NonOverlappingUpdateResultJob.perform_later(result, name: "B") }
 
     # Simulate expiry of the concurrency locks
     travel_to 3.days.from_now


### PR DESCRIPTION
Don't try to enforce sequential order for jobs, given that the order is not even guaranteed by Solid Queue. Rename the test job to reflect that. Fix also another test where we waited for a job to finish but not for it to release the semaphore, so it happened most of the times but sometimes it didn't.

See #602 