### PR TITLE
feat: allow using a pattern of file to specify multiple configurations of recurring tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,8 @@ Solid Queue supports defining recurring tasks that run at specific times in the 
 bin/jobs --recurring_schedule_file=config/schedule.yml
 ```
 
+It's also possible to define recurring tasks in several configuration files, for that specify a pattern of recurring tasks via `SolidQueue.recurring_config_file_pattern`.
+
 You can completely disable recurring tasks by setting the environment variable `SOLID_QUEUE_SKIP_RECURRING=true` or by using the `--skip-recurring` option with `bin/jobs`.
 
 The configuration itself looks like this:

--- a/lib/solid_queue.rb
+++ b/lib/solid_queue.rb
@@ -41,6 +41,8 @@ module SolidQueue
   mattr_accessor :clear_finished_jobs_after, default: 1.day
   mattr_accessor :default_concurrency_control_period, default: 3.minutes
 
+  mattr_accessor :recurring_config_file_pattern, default: SolidQueue::Configuration::DEFAULT_RECURRING_SCHEDULE_FILE_PATH
+
   delegate :on_start, :on_stop, :on_exit, to: Supervisor
 
   [ Dispatcher, Scheduler, Worker ].each do |process|

--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -154,7 +154,15 @@ module SolidQueue
 
       def recurring_tasks_config
         @recurring_tasks_config ||= begin
-          config_from options[:recurring_schedule_file]
+            if options.key?(:recurring_schedule_config_pattern)
+          matching_configurations = Dir.glob(Rails.root.join(options[:recurring_schedule_config_pattern]))
+            matching_configurations
+               .each_with_object({}) do |config_file, recurring_configuration|
+                recurring_configuration.merge!(config_from config_file)
+              end
+            else
+              config_from options[:recurring_schedule_file]
+            end
         end
       end
 

--- a/test/dummy/config/recurring_matching_pattern_a.yml
+++ b/test/dummy/config/recurring_matching_pattern_a.yml
@@ -1,0 +1,5 @@
+periodic_store_result_a:
+  class: StoreResultJob
+  queue: default
+  args: [ 42, { status: "custom_status" } ]
+  schedule: every second

--- a/test/dummy/config/recurring_matching_pattern_b.yml
+++ b/test/dummy/config/recurring_matching_pattern_b.yml
@@ -1,0 +1,5 @@
+periodic_store_result_b:
+  class: StoreResultJob
+  queue: default
+  args: [ 42, { status: "custom_status" } ]
+  schedule: every second

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -145,8 +145,8 @@ class ConfigurationTest < ActiveSupport::TestCase
       configuration.errors.full_messages.first
   end
 
-  test 'multiple recurring configuration files' do
-    configuration = SolidQueue::Configuration.new(recurring_schedule_config_pattern: 'config/recurring_matching_pattern_*.yml')
+  test "multiple recurring configuration files" do
+    configuration = SolidQueue::Configuration.new(recurring_schedule_config_pattern: "config/recurring_matching_pattern_*.yml")
 
     assert configuration.valid?
     assert_processes configuration, :scheduler, 1


### PR DESCRIPTION
Having only one file to configure recurring tasks is not optimal when handling several engines within the same codebase that are isolated from each other.

With these changes, it will be possible to define a pattern of config file paths (eg: `engines/*/config/solid_queue/recurring.yml`). 

Note:
- Should this new configuration option be available as well from the CLI? As it felt very advanced usage, I would say it should be configurable only via an initializer.
- Should this option be in addition of `recurring_schedule_file`? I can see a use case where transversal tasks are defined `config/recurring.yml` and others more oriented toward business topics are defined in `engines/*/config/solid_queue/recurring.yml`