### PR TITLE
force connection to configured database

### DIFF
--- a/app/models/solid_queue/record.rb
+++ b/app/models/solid_queue/record.rb
@@ -10,7 +10,8 @@ module SolidQueue
       def connection
         if SolidQueue.connects_to.present?
           role = SolidQueue.connects_to.dig(:database)&.keys&.first || :writing
-          connected_to(role: role) { super }        else
+          connected_to(role: role) { super }       
+        else
           super
         end
       end


### PR DESCRIPTION
This applies the same fix as applied to solid_cable, where table inspection queries were hitting postgres instead of the configured solid_cable database. Issue reference: https://github.com/rails/solid_cable/issues/63

```
2025-09-30 10:30:28.038 ADT [17244] ERROR:  relation "solid_queue_scheduled_executions" does not exist at character 523
2025-09-30 10:30:28.038 ADT [17244] STATEMENT:  SELECT a.attname, format_type(a.atttypid, a.atttypmod),
         pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
         c.collname, col_description(a.attrelid, a.attnum) AS comment,
         attidentity AS identity,
         attgenerated as attgenerated
    FROM pg_attribute a
    LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
    LEFT JOIN pg_type t ON a.atttypid = t.oid
    LEFT JOIN pg_collation c ON a.attcollation = c.oid AND a.attcollation <> t.typcollation
   WHERE a.attrelid = '"solid_queue_scheduled_executions"'::regclass
     AND a.attnum > 0 AND NOT a.attisdropped
   ORDER BY a.attnum
```