### PR TITLE
Wrap` Supervisor#start` and `stop` with the app executor

### DIFF
--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -29,18 +29,22 @@ module SolidQueue
     end
 
     def start
-      boot
-      run_start_hooks
+      wrap_in_app_executor do
+        boot
+        run_start_hooks
 
-      start_processes
-      launch_maintenance_task
+        start_processes
+        launch_maintenance_task
 
-      supervise
+        supervise
+      end
     end
 
     def stop
-      super
-      run_stop_hooks
+      wrap_in_app_executor do
+        super
+        run_stop_hooks
+      end
     end
 
     private


### PR DESCRIPTION
Wrap` Supervisor#start` and `stop` with the app executor to support applications that are using `Executor` callbacks or setting a custom app executor.