### PR TITLE
Removing non-deterministic check from `processes_lifecycle_test.rb`

### DIFF
--- a/test/integration/processes_lifecycle_test.rb
+++ b/test/integration/processes_lifecycle_test.rb
@@ -182,12 +182,6 @@ class ProcessesLifecycleTest < ActiveSupport::TestCase
     assert_completed_job_results("no exit", :background, 4)
     assert_completed_job_results("paused no exit", :default, 1)
 
-    # The background worker exits because of the exit job,
-    # leaving the pause job claimed
-    [ exit_job, pause_job ].each do |job|
-      assert_job_status(job, :claimed)
-    end
-
     assert process_exists?(@pid)
     terminate_process(@pid)
 


### PR DESCRIPTION
https://github.com/rails/solid_queue/pull/663 helped me quickly identify another source of flakiness from `processes_lifecycle_test.rb`. 

The combination of logs + GPT 5 is really powerful!

Run: https://github.com/p-schlickmann/solid_queue/actions/runs/18749897031/job/53486391931
Logs: https://github.com/p-schlickmann/solid_queue/actions/runs/18749897031/artifacts/4352196774

This test assumed that the background worker crash would leave both `exit_job` and `pause_job` in the `:claimed` state. In reality, this state is non-deterministic because the supervisor may detect the worker's death and fail the `:claimed` jobs before the assertion runs.

The test was updated to assert only the final, deterministic `:failed` state instead of relying on the transient `:claimed` state.

Another option to make it 100% deterministic would be pausing the supervisor before that check somehow, and than resume it right after. But I don't think that's a good idea.

Thoughts?
