### PR TITLE
Remove deprecated loading of `statistics.rake` from Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,9 @@ require "bundler/setup"
 APP_RAKEFILE = File.expand_path("test/dummy/Rakefile", __dir__)
 load "rails/tasks/engine.rake"
 
-load "rails/tasks/statistics.rake"
+if Rails::VERSION::MAJOR < 8
+  load "rails/tasks/statistics.rake"
+end
 
 require "bundler/gem_tasks"
 require "rake/tasklib"


### PR DESCRIPTION
While running the tests, I noticed a warning related to the `rails_main` tests.

```
DEPRECATION WARNING: rails/tasks/statistics.rake is deprecated and will be removed in Rails 8.2 without replacement.
 (called from load at /home/runner/work/solid_queue/solid_queue/Rakefile:8)
```

This happens because `rails/tasks/statistics.rake` loading is now deprecated in version 8.1.


Refs:
Loading introduced in: `Generate Rails engine and fill the basics` https://github.com/rails/solid_queue/commit/83835dbb6cc81b327f90d2ea63a2aa02fd393190
Deprecated in Rails 8.1 `Remove deprecated bin/rake stats command` https://github.com/rails/rails/commit/cf7d5e47a91ec68333cd18a02704471bedd047ac