### PR TITLE
Add wrap_in_app_executor in a few necessary places

### DIFF
--- a/lib/solid_queue/processes/registrable.rb
+++ b/lib/solid_queue/processes/registrable.rb
@@ -18,17 +18,19 @@ module SolidQueue::Processes
       attr_accessor :process
 
       def register
-        @process = SolidQueue::Process.register \
-          kind: kind,
-          name: name,
-          pid: pid,
-          hostname: hostname,
-          supervisor: try(:supervisor),
-          metadata: metadata.compact
+        wrap_in_app_executor do
+          @process = SolidQueue::Process.register \
+            kind: kind,
+            name: name,
+            pid: pid,
+            hostname: hostname,
+            supervisor: try(:supervisor),
+            metadata: metadata.compact
+        end
       end
 
       def deregister
-        process&.deregister
+        wrap_in_app_executor { process&.deregister }
       end
 
       def registered?

--- a/lib/solid_queue/scheduler/recurring_schedule.rb
+++ b/lib/solid_queue/scheduler/recurring_schedule.rb
@@ -46,7 +46,7 @@ module SolidQueue
       end
 
       def reload_tasks
-        @configured_tasks = SolidQueue::RecurringTask.where(key: task_keys)
+        @configured_tasks = SolidQueue::RecurringTask.where(key: task_keys).to_a
       end
 
       def schedule(task)

--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -176,9 +176,11 @@ module SolidQueue
       # executions it had claimed as failed so that they can be retried
       # by some other worker.
       def handle_claimed_jobs_by(terminated_fork, status)
-        if registered_process = SolidQueue::Process.find_by(name: terminated_fork.name)
-          error = Processes::ProcessExitError.new(status)
-          registered_process.fail_all_claimed_executions_with(error)
+        wrap_in_app_executor do
+          if registered_process = SolidQueue::Process.find_by(name: terminated_fork.name)
+            error = Processes::ProcessExitError.new(status)
+            registered_process.fail_all_claimed_executions_with(error)
+          end
         end
       end
 


### PR DESCRIPTION
`Process#register` and `#degister` for the supervisor to start up properly.

`RecurringSchedule#reload_tasks` resolves all the records immediately to avoid deferred resolution outside the executor block.

`Supervisor#handle_claimed_jobs_by` wraps its code in the executor.

A second attempt at #655 without causing the issues from #670

This PR unfortunately doesn't add any tests; I tried and failed to come up with a strategy that would check all database code was wrapped properly that didn't involve massive restructuring of tests. If you have any good ideas on how to do that, please let me know.

(As an aside, the reason for this PR and #655 is that I'm working on multi-tenant support for Solid Queue, using Active Record Tenanted which relies on Rails' sharding features. I'd like to use the app executor's run/complete callbacks to set/unset the shard.)