### PR TITLE
Attempt to reduce flakiness of `recurring_tasks_test`

### DIFF
--- a/test/integration/recurring_tasks_test.rb
+++ b/test/integration/recurring_tasks_test.rb
@@ -30,8 +30,6 @@ class RecurringTasksTest < ActiveSupport::TestCase
         assert_equal "42", result.value
       end
     end
-
-    # no need to stop @pid supervisor - that will be handled in teardown
   end
 
   test "persist and delete configured tasks" do
@@ -61,8 +59,6 @@ class RecurringTasksTest < ActiveSupport::TestCase
 
     scheduler1.stop
     scheduler2.stop
-
-    # no need to stop @pid supervisor - that will be handled in teardown
   end
 
   private
@@ -93,6 +89,5 @@ class RecurringTasksTest < ActiveSupport::TestCase
 
       terminate_process(pid)
       wait_for_registered_processes(0, timeout: SolidQueue.shutdown_timeout)
-      sleep SolidQueue.shutdown_timeout
     end
 end


### PR DESCRIPTION
Issue: https://github.com/rails/solid_queue/issues/602
Flake: [recurring_tasks_test.rb](https://github.com/rails/solid_queue/blob/main/test/integration/recurring_tasks_test.rb)
Failed run: https://github.com/rails/solid_queue/actions/runs/18916883193/job/54002506057
Instructions to validate the fix locally: https://github.com/rails/solid_queue/pull/678

### Summary
I found a race condition in [recurring_tasks_test.rb](https://github.com/rails/solid_queue/blob/main/test/integration/recurring_tasks_test.rb) which tries to stop the supervisor twice. Once inside the test and once again in `teardown`. 

When synchronized enough, the first shutdown worked, and the second one tried to stop a process that had already exited. That second attempt escalated to a `KILL` instead of a clean `TERM`, which is why the assertion [failed in CI](https://github.com/rails/solid_queue/actions/runs/18916883193/job/54002506057).

The fix makes sure we only stop the supervisor once, removing the double-shutdown race.