### PR TITLE
Fixed indentation for the adapter line in the README’s cable.yml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ In `config/cable.yml`
 ```diff
 development:
 -  adapter: async
-+ adapter: solid_cable
++  adapter: solid_cable
 +  connects_to:
 +    database:
 +      writing: cable


### PR DESCRIPTION
Hi, while configuring cable.yml for the development environment using the README, I noticed that the indentation in the README would cause an error if used as-is.
It’s a small fix, but to prevent confusion for future readers, I’m sending a pull request.