### PR TITLE
Fix spacing for `database.yml` in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ development:
 + primary:
     <<: *default
     database: storage/development.sqlite3
-+  queue:
-+    <<: *default
-+    database: storage/development_queue.sqlite3
-+    migrations_paths: db/queue_migrate
++ queue:
++   <<: *default
++   database: storage/development_queue.sqlite3
++   migrations_paths: db/queue_migrate
 ```
 
 Next, add the following to `development.rb`


### PR DESCRIPTION
I noticed the spacing was off when configuring multiple databases for the `development` environment.