### PR TITLE
Fix NoMethodError when status.exitstatus is nil

### DIFF
--- a/lib/solid_queue/fork_supervisor.rb
+++ b/lib/solid_queue/fork_supervisor.rb
@@ -38,7 +38,7 @@ module SolidQueue
         pid, status = ::Process.waitpid2(-1, ::Process::WNOHANG)
         break unless pid
 
-        if (terminated_fork = process_instances.delete(pid)) && !status.exited? || status.exitstatus > 0
+        if (terminated_fork = process_instances.delete(pid)) && (!status.exited? || status.exitstatus.to_i > 0)
           error = Processes::ProcessExitError.new(status)
           release_claimed_jobs_by(terminated_fork, with_error: error)
         end


### PR DESCRIPTION
When a worker process is terminated by certain signals (e.g., SIGTERM, SIGKILL), status.exitstatus returns nil, causing a NoMethodError due to operator precedence in the conditional.

This fix:
1. Adds parentheses to ensure proper evaluation order
2. Uses .to_i to safely convert nil to 0, preventing the NoMethodError

Fixes the error: NoMethodError: undefined method '>' for nil