### PR TITLE
Fix typo in error message

### DIFF
--- a/app/models/solid_queue/recurring_task.rb
+++ b/app/models/solid_queue/recurring_task.rb
@@ -110,7 +110,7 @@ module SolidQueue
 
       def ensure_command_or_class_present
         unless command.present? || class_name.present?
-          errors.add :base, :command_and_class_blank, message: "either command or class_name must be present"
+          errors.add :base, :command_and_class_blank, message: "either command or class must be present"
         end
       end
 

--- a/test/models/solid_queue/recurring_task_test.rb
+++ b/test/models/solid_queue/recurring_task_test.rb
@@ -154,7 +154,9 @@ class SolidQueue::RecurringTaskTest < ActiveSupport::TestCase
     assert_not recurring_task_with(class_name: "UnknownJob").valid?
 
     # Empty class name and command
-    assert_not recurring_task_with(key: "task-id", schedule: "every minute").valid?
+    task = SolidQueue::RecurringTask.from_configuration("task-id", schedule: "every minute")
+    assert_not task.valid?
+    assert_includes task.errors[:base], "either command or class must be present"
   end
 
   test "task with custom queue and priority" do


### PR DESCRIPTION
Hi! I ran into what I think is a typo today that confused me for a minute.

After accidentally deploying an invalid job config in recurring.yml:
```yaml
  incineration:
    job: Account::IncinerateDueJob # <- invalid "job" key
    schedule: every 8 hours at minute 16
```

I got this error message when SolidQueue tried to boot:

```
Invalid recurring tasks:
- incineration: either command or class_name must be present
Exiting...
```

I then changed `job` to `class_name` as the error told me to, but that resulted in the same error.
```yaml
  incineration:
    class_name: Account::IncinerateDueJob # <- still raises "either command or class_name must be present"
    schedule: every 8 hours at minute 16
```

Only after checking the documentation did I notice that the key should be `class` instead of `class_name`
```yaml
  incineration:
    class: Account::IncinerateDueJob # <- this works
    schedule: every 8 hours at minute 16
```

This PR changes `class_name` to be just `class` in the error message and adds a test for it.