### PR TITLE
Remove trapping QUIT on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ The supervisor is in charge of managing these processes, and it responds to the 
 
 When receiving a `QUIT` signal, if workers still have jobs in-flight, these will be returned to the queue when the processes are deregistered.
 
+On Windows, the `QUIT` signal can't be trapped, so the supervisor only responds to `TERM` and `INT` there.
+
 If processes have no chance of cleaning up before exiting (e.g. if someone pulls a cable somewhere), in-flight jobs might remain claimed by the processes executing them. Processes send heartbeats, and the supervisor checks and prunes processes with expired heartbeats. Jobs that were claimed by processes with an expired heartbeat will be marked as failed with a `SolidQueue::Processes::ProcessPrunedError`. You can configure both the frequency of heartbeats and the threshold to consider a process dead. See the section below for this.
 
 In a similar way, if a worker is terminated in any other way not initiated by the above signals (e.g. a worker is sent a `KILL` signal), jobs in progress will be marked as failed so that they can be inspected, with a `SolidQueue::Processes::ProcessExitError`. Sometimes a job in particular is responsible for this, for example, if it has a memory leak and you have a mechanism to kill processes over a certain memory threshold, so this will help identifying this kind of situation.

--- a/lib/solid_queue/supervisor/signals.rb
+++ b/lib/solid_queue/supervisor/signals.rb
@@ -11,7 +11,11 @@ module SolidQueue
       end
 
       private
-        SIGNALS = %i[ QUIT INT TERM ]
+        SIGNALS = if Gem.win_platform?
+                    %i[ INT TERM ]
+        else
+                    %i[ QUIT INT TERM ]
+        end
 
         def register_signal_handlers
           SIGNALS.each do |signal|

--- a/lib/solid_queue/supervisor/signals.rb
+++ b/lib/solid_queue/supervisor/signals.rb
@@ -11,7 +11,7 @@ module SolidQueue
       end
 
       private
-        SIGNALS = %i[ QUIT INT TERM ]
+        SIGNALS = Gem.win_platform? ? %i[ INT TERM ] : %i[ QUIT INT TERM ]
 
         def register_signal_handlers
           SIGNALS.each do |signal|


### PR DESCRIPTION
Windows does not support trapping `QUIT`, but everything else. To keep the constant I suggest to implement an `if` switch.