### PR TITLE
Fix recurring task logging as if it enqueued the same job twice

### DIFF
--- a/app/models/solid_queue/recurring_task.rb
+++ b/app/models/solid_queue/recurring_task.rb
@@ -56,8 +56,9 @@ module SolidQueue
       end
     end
 
-    def delay_from_now
-      [ (next_time - Time.current).to_f, 0.1 ].max
+
+    def next_time_after(time)
+      parsed_schedule.next_time(time).utc
     end
 
     def next_time

--- a/lib/solid_queue/scheduler/recurring_schedule.rb
+++ b/lib/solid_queue/scheduler/recurring_schedule.rb
@@ -33,8 +33,8 @@ module SolidQueue
       end
     end
 
-    def schedule_task(task)
-      scheduled_tasks[task.key] = schedule(task)
+    def schedule_task(task, run_at: task.next_time)
+      scheduled_tasks[task.key] = schedule(task, run_at: run_at)
     end
 
     def unschedule_tasks
@@ -99,9 +99,11 @@ module SolidQueue
         dynamic_tasks_enabled? ? RecurringTask.dynamic.to_a : []
       end
 
-      def schedule(task)
-        scheduled_task = Concurrent::ScheduledTask.new(task.delay_from_now, args: [ self, task, task.next_time ]) do |thread_schedule, thread_task, thread_task_run_at|
-          thread_schedule.schedule_task(thread_task)
+      def schedule(task, run_at: task.next_time)
+        delay = [ (run_at - Time.current).to_f, 0.1 ].max
+
+        scheduled_task = Concurrent::ScheduledTask.new(delay, args: [ self, task, run_at ]) do |thread_schedule, thread_task, thread_task_run_at|
+          thread_schedule.schedule_task(thread_task, run_at: thread_task.next_time_after(thread_task_run_at))
 
           wrap_in_app_executor do
             thread_task.enqueue(at: thread_task_run_at)

--- a/test/models/solid_queue/recurring_task_test.rb
+++ b/test/models/solid_queue/recurring_task_test.rb
@@ -203,6 +203,18 @@ class SolidQueue::RecurringTaskTest < ActiveSupport::TestCase
     assert_equal 4, job.priority
   end
 
+  test "next_time_after returns the next occurrence after the given time" do
+    task = recurring_task_with(class_name: "JobWithoutArguments", schedule: "every minute")
+
+    # next_time_after a time exactly on the minute boundary should return the following minute
+    time = Time.utc(2026, 3, 12, 1, 28, 0)
+    assert_equal Time.utc(2026, 3, 12, 1, 29, 0), task.next_time_after(time)
+
+    # next_time_after a time just before the boundary should return that boundary
+    time = Time.utc(2026, 3, 12, 1, 27, 59)
+    assert_equal Time.utc(2026, 3, 12, 1, 28, 0), task.next_time_after(time)
+  end
+
   test "task configured with a command" do
     task = recurring_task_with(command: "JobBuffer.add('from_a_command')")
     enqueue_and_assert_performed_with_result(task, "from_a_command")


### PR DESCRIPTION
A bug exists with recurring task enqueuing, where you will sometimes see doubled up `[ActiveJob] Enqueued ...` log lines. On Postgres these do not result in doubled up enqueueing, but they do result in confusing log lines. For example, given a `QueueHeartbeatJob` that's meant to run every minute:

```
2026-04-09T06:50:00Z app[e823931b293218] syd [info][ActiveJob] Enqueued QueueHeartbeatJob (Job ID: f3f21750-2d6b-416e-a1f3-5a1235744825) to SolidQueue(default)
2026-04-09T06:50:00Z app[e823931b293218] syd [info][ActiveJob] [QueueHeartbeatJob] [f3f21750-2d6b-416e-a1f3-5a1235744825] Performing QueueHeartbeatJob (Job ID: f3f21750-2d6b-416e-a1f3-5a1235744825) from SolidQueue(default) enqueued at 2026-04-09T06:50:00.002768396Z
2026-04-09T06:50:00Z app[e823931b293218] syd [info][ActiveJob] [QueueHeartbeatJob] [f3f21750-2d6b-416e-a1f3-5a1235744825] Performed QueueHeartbeatJob (Job ID: f3f21750-2d6b-416e-a1f3-5a1235744825) from SolidQueue(default) in 11.79ms
2026-04-09T06:51:00Z app[e823931b293218] syd [info][ActiveJob] Enqueued QueueHeartbeatJob (Job ID: e32694c9-eeb8-4079-bc7c-6c77a405fd6f) to SolidQueue(default)
2026-04-09T06:51:00Z app[e823931b293218] syd [info][ActiveJob] [QueueHeartbeatJob] [e32694c9-eeb8-4079-bc7c-6c77a405fd6f] Performing QueueHeartbeatJob (Job ID: e32694c9-eeb8-4079-bc7c-6c77a405fd6f) from SolidQueue(default) enqueued at 2026-04-09T06:51:00.001187865Z
2026-04-09T06:51:00Z app[e823931b293218] syd [info][ActiveJob] [QueueHeartbeatJob] [e32694c9-eeb8-4079-bc7c-6c77a405fd6f] Performed QueueHeartbeatJob (Job ID: e32694c9-eeb8-4079-bc7c-6c77a405fd6f) from SolidQueue(default) in 9.0ms
2026-04-09T06:52:00Z app[e823931b293218] syd [info][ActiveJob] Enqueued QueueHeartbeatJob (Job ID: e60a1384-4b46-4c97-94bc-7dd695d1cfdb) to SolidQueue(default)
2026-04-09T06:53:00Z app[e823931b293218] syd [info][ActiveJob] Enqueued QueueHeartbeatJob (Job ID: d5f795de-080c-47bd-88e2-0e33520aa470) to SolidQueue(default)
2026-04-09T06:53:00Z app[e823931b293218] syd [info][ActiveJob] [QueueHeartbeatJob] [d5f795de-080c-47bd-88e2-0e33520aa470] Performing QueueHeartbeatJob (Job ID: d5f795de-080c-47bd-88e2-0e33520aa470) from SolidQueue(default) enqueued at 2026-04-09T06:53:00.009200319Z
2026-04-09T06:53:00Z app[e823931b293218] syd [info][ActiveJob] [QueueHeartbeatJob] [d5f795de-080c-47bd-88e2-0e33520aa470] Performed QueueHeartbeatJob (Job ID: d5f795de-080c-47bd-88e2-0e33520aa470) from SolidQueue(default) in 15.97ms
```

To find the root cause, I deployed SQ with [extra logging](https://github.com/rails/solid_queue/compare/main...ghiculescu:solid_queue:log-enqueue_recurring_task). If we include those logs and remove the job being performed it makes it easier to see what's going on:

```
2026-04-09T06:50:00Z app[e823931b293218] syd [info]schedule: QueueHeartbeatJob.perform_later() [ * * * * * ], delay = 59.998386254, next time = 2026-04-09 06:51:00 UTC (now = 2026-04-09 06:50:00 UTC, diff = 59.999722945)
2026-04-09T06:50:00Z app[e823931b293218] syd [info][ActiveJob] Enqueued QueueHeartbeatJob (Job ID: f3f21750-2d6b-416e-a1f3-5a1235744825) to SolidQueue(default)
2026-04-09T06:50:00Z app[e823931b293218] syd [info]SolidQueue-1.4.0 Enqueued recurring task (17.0ms)  task: "queue_heartbeat", active_job_id: "f3f21750-2d6b-416e-a1f3-5a1235744825", at: "2026-04-09T06:50:00Z"
2026-04-09T06:51:00Z app[e823931b293218] syd [info]schedule: QueueHeartbeatJob.perform_later() [ * * * * * ], delay = 59.999577626, next time = 2026-04-09 06:51:00 UTC (now = 2026-04-09 06:50:59 UTC, diff = 8.0566e-05)
2026-04-09T06:51:00Z app[e823931b293218] syd [info][ActiveJob] Enqueued QueueHeartbeatJob (Job ID: e32694c9-eeb8-4079-bc7c-6c77a405fd6f) to SolidQueue(default)
2026-04-09T06:51:00Z app[e823931b293218] syd [info]SolidQueue-1.4.0 Enqueued recurring task (19.1ms)  task: "queue_heartbeat", active_job_id: "e32694c9-eeb8-4079-bc7c-6c77a405fd6f", at: "2026-04-09T06:51:00Z"
2026-04-09T06:52:00Z app[e823931b293218] syd [info]schedule: QueueHeartbeatJob.perform_later() [ * * * * * ], delay = 59.99585098, next time = 2026-04-09 06:53:00 UTC (now = 2026-04-09 06:52:00 UTC, diff = 59.999882842)
2026-04-09T06:52:00Z app[e823931b293218] syd [info][ActiveJob] Enqueued QueueHeartbeatJob (Job ID: e60a1384-4b46-4c97-94bc-7dd695d1cfdb) to SolidQueue(default)
2026-04-09T06:52:00Z app[e823931b293218] syd [info]SolidQueue-1.4.0 Skipped recurring task – already dispatched (20.4ms)  task: "queue_heartbeat", at: "2026-04-09T06:51:00Z"
2026-04-09T06:53:00Z app[e823931b293218] syd [info]schedule: QueueHeartbeatJob.perform_later() [ * * * * * ], delay = 59.993155042, next time = 2026-04-09 06:54:00 UTC (now = 2026-04-09 06:52:59 UTC, diff = 60.000016247)
2026-04-09T06:53:00Z app[e823931b293218] syd [info][ActiveJob] Enqueued QueueHeartbeatJob (Job ID: d5f795de-080c-47bd-88e2-0e33520aa470) to SolidQueue(default)
2026-04-09T06:53:00Z app[e823931b293218] syd [info]SolidQueue-1.4.0 Enqueued recurring task (16.4ms)  task: "queue_heartbeat", active_job_id: "d5f795de-080c-47bd-88e2-0e33520aa470", at: "2026-04-09T06:53:00Z"
```

On line 1, `next time = 2026-04-09 06:51:00 UTC` - that's when we expect the next `Concurrent::ScheduledTask` to fire. On line 4 we see it's actually fired at `2026-04-09 06:50:59 UTC`. As a result, the new `next_time` is incorrectly calculated as the current time. A job has already been enqueued for `06:51` so the second attempt will result in a uniqueness validation - but not before the `[ActiveJob] Enqueued QueueHeartbeatJob` line is logged.

This PR fixes this by calculating `next_time` in terms of when we thought the `Concurrent::ScheduledTask` would fire, not the actual time. This handles the case where it executes milliseconds earlier than we expected to.