### PR TITLE
Fix flaky Puma plugin tests caused by port collision

### DIFF
--- a/test/integration/puma/plugin_testing.rb
+++ b/test/integration/puma/plugin_testing.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "socket"
 
 module PluginTesting
   extend ActiveSupport::Concern
@@ -12,10 +13,12 @@ module PluginTesting
     setup do
       FileUtils.mkdir_p Rails.root.join("tmp", "pids")
 
+      @port = find_available_port
+
       Dir.chdir("test/dummy") do
         cmd = %W[
           bundle exec puma
-            -b tcp://127.0.0.1:9222
+            -b tcp://127.0.0.1:#{@port}
             -C config/puma_#{solid_queue_mode}.rb
             -s
             config.ru
@@ -56,5 +59,12 @@ module PluginTesting
   private
     def solid_queue_mode
       raise NotImplementedError
+    end
+
+    def find_available_port
+      server = TCPServer.new("127.0.0.1", 0)
+      server.addr[1]
+    ensure
+      server&.close
     end
 end


### PR DESCRIPTION
## Summary

Related to #602.

Puma plugin tests bind to a hardcoded port (9222). When consecutive tests run, the OS may still hold the previous port in TCP TIME_WAIT state, causing `EADDRINUSE` that cascades into false test failures.

This replaces the fixed port with dynamic allocation via `TCPServer`, so each test gets a guaranteed available port.

To be precise, this PR should fix this flaky test, for instance: https://github.com/rails/solid_queue/actions/runs/24190892956/job/70607570480?pr=732

## What changed

| File | Change |
|------|--------|
| `test/integration/puma/plugin_testing.rb` | Replace hardcoded port 9222 with `TCPServer.new("127.0.0.1", 0)` dynamic allocation |