### PR TITLE
Fix flaky concurrency controls test

### DIFF
--- a/test/integration/concurrency_controls_test.rb
+++ b/test/integration/concurrency_controls_test.rb
@@ -166,12 +166,11 @@ class ConcurrencyControlsTest < ActiveSupport::TestCase
     NonOverlappingUpdateResultJob.perform_later(@result, name: "I'll be released to ready", pause: SolidQueue.shutdown_timeout + 10.seconds)
     job = SolidQueue::Job.last
 
-    sleep(0.2)
-    assert job.claimed?
+    wait_for(timeout: 2.seconds) { job.reload.claimed? }
 
-    # This won't leave time to the job to finish
-    signal_process(@pid, :TERM, wait: 0.1.second)
-    sleep(SolidQueue.shutdown_timeout + 0.6.seconds)
+    # This won't leave time to the job to finish, so the worker should
+    # release it back to ready during shutdown.
+    terminate_process(@pid)
 
     assert_not job.reload.finished?
     assert job.reload.ready?


### PR DESCRIPTION
Related to #602.

## Summary

An attempt to fix the flaky `ConcurrencyControlsTest#test_don't_block_claimed_executions_that_get_released` test, which intermittently fails on CI with `job.reload.finished?` returning `true` unexpectedly. See: https://github.com/rails/solid_queue/actions/runs/24191921225/job/70611172823?pr=733

## Problem

The test relies on fixed sleeps to synchronize with forked processes:

```ruby
sleep(0.2)                                        # hope the worker has claimed by now
signal_process(@pid, :TERM, wait: 0.1.second)     # send TERM in a thread
sleep(SolidQueue.shutdown_timeout + 0.6.seconds)   # hope shutdown is done by now
```

**Hypothesis:**

On slow CI runners, these margins can be insufficient. The supervisor shutdown sequence involves TERM to children, a 5s wait, then QUIT if children haven't exited. Both the supervisor's timer and the worker's `pool.wait_for_termination` use the same 5s `shutdown_timeout`, creating a race where the supervisor may QUIT a worker mid deregister. With fixed sleeps, the test checks job state before the shutdown has fully completed, leading to unpredictable results.

## Fix

Replace timing guesswork with deterministic waits:

- `sleep(0.2)` + `assert job.claimed?` becomes `wait_for(timeout: 2.seconds) { job.reload.claimed? }`, which polls until the job is actually claimed
- `signal_process` + `sleep(shutdown_timeout + 0.6)` becomes `terminate_process(@pid)`, which sends TERM and blocks on `waitpid2` until the supervisor has actually exited

By the time `terminate_process` returns, the supervisor and all its children have exited, and claimed executions have been released. No timing assumptions needed.
