### PR TITLE
Add Rake task to validate complete recurring configuration

### DIFF
--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -70,7 +70,7 @@ module SolidQueue
     end
 
     def valid_recurring_config?
-      invalid_tasks = Hash.new {|hash, key| hash[key] = [] }
+      invalid_tasks = Hash.new { |hash, key| hash[key] = [] }
       load_config_from(options[:recurring_schedule_file]).each do |env, tasks|
         tasks.each do |id, options|
           task = RecurringTask.from_configuration(id, **options)

--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -69,19 +69,35 @@ module SolidQueue
       mode.fork? || @options[:standalone]
     end
 
-    def validate_recurring_config
-      valid = true
+    def valid_recurring_config?
+      invalid = false
+      invalid_tasks = Hash.new {|hash, key| hash[key] = [] }
       load_config_from(options[:recurring_schedule_file]).each do |env, tasks|
         tasks.each do |id, options|
-          if options&.has_key?(:schedule) && RecurringTask.from_configuration(id, **options).invalid?
-            STDERR.puts "Invalid recurring task #{id} in #{env}: #{options[:schedule]}"
-            valid = false
+          task = RecurringTask.from_configuration(id, **options)
+          if task.invalid?
+            invalid_tasks[env] << task
+            invalid = true
           end
         end
       end
 
-      puts "All recurring tasks are valid" if valid
-      valid
+      if invalid
+        puts "Invalid recurring tasks:"
+        invalid_tasks.each do |env, tasks|
+          puts "- #{env}"
+          tasks.each do |task|
+            puts "  - #{task.key}"
+            task.errors.full_messages.each do |message|
+              puts "    - #{message}"
+            end
+          end
+        end
+        false
+      else
+        puts "All recurring tasks are valid"
+        true
+      end
     end
 
     private

--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -70,34 +70,30 @@ module SolidQueue
     end
 
     def valid_recurring_config?
-      invalid = false
       invalid_tasks = Hash.new {|hash, key| hash[key] = [] }
       load_config_from(options[:recurring_schedule_file]).each do |env, tasks|
         tasks.each do |id, options|
           task = RecurringTask.from_configuration(id, **options)
-          if task.invalid?
-            invalid_tasks[env] << task
-            invalid = true
-          end
+          invalid_tasks[env] << task if task.invalid?
         end
       end
 
-      if invalid
-        puts "Invalid recurring tasks:"
-        invalid_tasks.each do |env, tasks|
-          puts "- #{env}"
-          tasks.each do |task|
-            puts "  - #{task.key}"
-            task.errors.full_messages.each do |message|
-              puts "    - #{message}"
-            end
+      if invalid_tasks.empty?
+        puts "All recurring tasks are valid"
+        return true
+      end
+
+      puts "Invalid recurring tasks:"
+      invalid_tasks.each do |env, tasks|
+        puts "- #{env}"
+        tasks.each do |task|
+          puts "  - #{task.key}"
+          task.errors.full_messages.each do |message|
+            puts "    - #{message}"
           end
         end
-        false
-      else
-        puts "All recurring tasks are valid"
-        true
       end
+      false
     end
 
     private

--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -69,6 +69,21 @@ module SolidQueue
       mode.fork? || @options[:standalone]
     end
 
+    def validate_recurring_config
+      valid = true
+      load_config_from(options[:recurring_schedule_file]).each do |env, tasks|
+        tasks.each do |id, options|
+          if options&.has_key?(:schedule) && RecurringTask.from_configuration(id, **options).invalid?
+            STDERR.puts "Invalid recurring task #{id} in #{env}: #{options[:schedule]}"
+            valid = false
+          end
+        end
+      end
+
+      puts "All recurring tasks are valid" if valid
+      valid
+    end
+
     private
       attr_reader :options
 

--- a/lib/solid_queue/tasks.rb
+++ b/lib/solid_queue/tasks.rb
@@ -8,4 +8,9 @@ namespace :solid_queue do
   task start: :environment do
     SolidQueue::Supervisor.start
   end
+
+  desc "Validates the recurring jobs config"
+  task validate_recurring_config: :environment do
+    SolidQueue::Configuration.new.validate_recurring_config
+  end
 end

--- a/lib/solid_queue/tasks.rb
+++ b/lib/solid_queue/tasks.rb
@@ -11,6 +11,6 @@ namespace :solid_queue do
 
   desc "Validates the recurring jobs config"
   task validate_recurring_config: :environment do
-    SolidQueue::Configuration.new.validate_recurring_config
+    abort unless SolidQueue::Configuration.new.valid_recurring_config?
   end
 end


### PR DESCRIPTION
This PR is my attempt at a solution for the problems described in #722. It adds a Rake task `validate_recurring_config` which loads the recurring task configuration (not only for the current RAILS_ENV) and asserts whether every task definition is valid. If any task is invalid, it exits with a non-zero code and prints the validation errors to stdout. If all tasks are valid, it prints 'All recurring tasks are valid' and exits with code 0.

One problem it still has is that it only works for configurations split by Rails environment; if you define tasks in the top-level (like `recurring_with_invalid.yml` in the dummy app), you get an exception. I'm open for suggestions how to fix that.

There are also no tests yet, let me know if you would like me to add those.