### PR TITLE
Ignore closed-terminal log errors in Puma plugin shutdown

### DIFF
--- a/lib/puma/plugin/solid_queue.rb
+++ b/lib/puma/plugin/solid_queue.rb
@@ -129,5 +129,8 @@ Puma::Plugin.create do
 
     def log(...)
       log_writer.log(...)
+    rescue Errno::EIO
+      # The controlling terminal can disappear before the monitor thread shuts
+      # down the child process. Keep shutdown moving even when logging cannot.
     end
 end

--- a/test/unit/puma_plugin_test.rb
+++ b/test/unit/puma_plugin_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "puma/plugin/solid_queue"
+
+class PumaPluginTest < ActiveSupport::TestCase
+  class ClosedTerminalLogWriter
+    def log(...)
+      raise Errno::EIO
+    end
+  end
+
+  test "monitor still stops the process when shutdown logging fails" do
+    plugin = Puma::Plugins.find("solid_queue").new
+    plugin.instance_variable_set(:@log_writer, ClosedTerminalLogWriter.new)
+
+    plugin.stubs(:puma_dead?).returns(true)
+    Process.expects(:kill).with(:INT, Process.pid)
+
+    plugin.send(:monitor, :puma_dead?, "Detected Puma has gone away, stopping Solid Queue...")
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #737.

When the Puma plugin monitor detects that Puma has gone away, it logs a shutdown message before sending `INT` to stop Solid Queue. If the controlling terminal has already been closed, Puma's log writer can raise `Errno::EIO`, preventing the shutdown signal from being sent.

This makes plugin logging tolerate `Errno::EIO` so shutdown can continue.

## Changes

- Rescue `Errno::EIO` from the Puma plugin `log` helper
- Add a unit test proving the monitor still sends the shutdown signal when logging fails

## Validation

- `TARGET_DB=sqlite RBENV_VERSION=3.4.4 bundle _2.5.16_ exec ruby -Itest test/unit/puma_plugin_test.rb`
- `TARGET_DB=sqlite RBENV_VERSION=3.4.4 bundle exec ruby -Itest test/integration/puma/plugin_async_test.rb`
- `TARGET_DB=sqlite RBENV_VERSION=3.4.4 bundle exec ruby -Itest test/integration/puma/plugin_fork_test.rb`
- `RBENV_VERSION=3.4.4 bundle exec rubocop lib/puma/plugin/solid_queue.rb test/unit/puma_plugin_test.rb`
