### PR TITLE
Avoid reloading job rows after dispatch and schedule

### DIFF
--- a/app/models/solid_queue/job/executable.rb
+++ b/app/models/solid_queue/job/executable.rb
@@ -41,15 +41,16 @@ module SolidQueue
           end
 
           def successfully_dispatched(jobs)
-            dispatched_and_ready(jobs) + dispatched_and_blocked(jobs)
+            jobs_by_id = jobs.index_by(&:id)
+            dispatched_and_ready(jobs_by_id) + dispatched_and_blocked(jobs_by_id)
           end
 
-          def dispatched_and_ready(jobs)
-            where(id: ReadyExecution.where(job_id: jobs.map(&:id)).pluck(:job_id))
+          def dispatched_and_ready(jobs_by_id)
+            ReadyExecution.where(job_id: jobs_by_id.keys).pluck(:job_id).map { |id| jobs_by_id[id] }
           end
 
-          def dispatched_and_blocked(jobs)
-            where(id: BlockedExecution.where(job_id: jobs.map(&:id)).pluck(:job_id))
+          def dispatched_and_blocked(jobs_by_id)
+            BlockedExecution.where(job_id: jobs_by_id.keys).pluck(:job_id).map { |id| jobs_by_id[id] }
           end
       end
 

--- a/app/models/solid_queue/job/schedulable.rb
+++ b/app/models/solid_queue/job/schedulable.rb
@@ -23,7 +23,8 @@ module SolidQueue
           end
 
           def successfully_scheduled(jobs)
-            where(id: ScheduledExecution.where(job_id: jobs.map(&:id)).pluck(:job_id))
+            jobs_by_id = jobs.index_by(&:id)
+            ScheduledExecution.where(job_id: jobs_by_id.keys).pluck(:job_id).map { |id| jobs_by_id[id] }
           end
       end
 


### PR DESCRIPTION
In `Job.dispatch_all` and `Job.schedule_all` (the hot path of `enqueue_all` / `ActiveJob.perform_all_later`), the post-insert step rebuilt the returned set with:

  where(id: <Execution>.where(job_id: jobs.map(&:id)).pluck(:job_id))

which always issues two statements per execution table -- a `pluck` on the execution table and a follow-up `SELECT ... FROM solid_queue_jobs WHERE id IN (...)` -- to re-read rows we already hold in memory. The `Job` instances passed in are the ones just returned by `create_all_from_active_jobs`, so they are persisted and have ids.

Filter `jobs` in memory against the plucked execution ids instead.

Per `enqueue_all` batch:

  * dispatch_all:  4 queries -> 2 (drops the two job-table reloads)
  * schedule_all:  2 queries -> 1 (drops the job-table reload)

The avoided `SELECT` is the most expensive of the four: it scans the wide `solid_queue_jobs` row including the serialized `arguments` payload, so the saving is bytes-over-the-wire and not just a round trip.

Semantic equivalence:

  * Each job is inserted into at most one of ready_executions / blocked_executions / scheduled_executions in this code path, so the in-memory filter selects exactly the same job ids the prior `where(id: ...)` would have returned.
  * Both call sites (`prepare_all_for_execution` which concatenates with `+`, and `Execution::Dispatching#dispatch_jobs` which calls `.map(&:id)`) already coerce the result to an Array and do not depend on it being an `ActiveRecord::Relation` or on row order.
  * `jobs` is the same collection that was just queried back in `create_all_from_active_jobs`, so attribute freshness is unchanged versus the previous reload.

Verified against the existing `job_test`, `ready_execution_test`, `dispatcher_test`, and `concurrency_controls_test` suites on SQLite (55 runs, 0 failures).