### PR TITLE
Accept optional job argument in stopping?

### DIFF
--- a/lib/active_job/queue_adapters/solid_queue_adapter.rb
+++ b/lib/active_job/queue_adapters/solid_queue_adapter.rb
@@ -8,8 +8,16 @@ module ActiveJob
     #
     #   Rails.application.config.active_job.queue_adapter = :solid_queue
     class SolidQueueAdapter < (Rails::VERSION::MAJOR == 7 && Rails::VERSION::MINOR == 1 ? Object : AbstractAdapter)
-      class_attribute :stopping, default: false, instance_writer: false
+      class_attribute :stopping, default: false, instance_writer: false, instance_predicate: false
       SolidQueue.on_worker_stop { self.stopping = true }
+
+      # Accept an optional job argument for compatibility with Rails main, which
+      # began passing the running job to +queue_adapter.stopping?+ so adapters can
+      # decide whether to checkpoint based on it. We rely solely on the worker
+      # shutdown flag, so the argument is ignored.
+      def stopping?(_job = nil)
+        self.class.stopping
+      end
 
       def enqueue_after_transaction_commit?
         true


### PR DESCRIPTION
Rails commit [6d1c401dc7 ("Pass job instance to stopping?")](https://github.com/rails/rails/commit/6d1c401dc7c73e2a39ffbd42a22678cbbcf23d17) changed `ActiveJob::Continuable#checkpoint!` to call `queue_adapter.stopping?(self)`, passing the running job so adapters can decide whether to checkpoint based on it.

This caused errors such as:

    ArgumentError: wrong number of arguments (given 1, expected 0)

The new argument is ignored. Solid Queue still relies solely on the worker shutdown flag. But the signature is now compatible with both the new and old Rails calling conventions.