### PR TITLE
docs: use single splat in `key` argument for `limits_concurrency`

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ Solid Queue extends Active Job with concurrency controls, that allows you to lim
 
 ```ruby
 class MyJob < ApplicationJob
-  limits_concurrency to: max_concurrent_executions, key: ->(arg1, arg2, **) { ... }, duration: max_interval_to_guarantee_concurrency_limit, group: concurrency_group, on_conflict: on_conflict_behaviour
+  limits_concurrency to: max_concurrent_executions, key: ->(arg1, arg2, *) { ... }, duration: max_interval_to_guarantee_concurrency_limit, group: concurrency_group, on_conflict: on_conflict_behaviour
 
   # ...
 ```


### PR DESCRIPTION
Using a double splat means that an error will be raised if more than two non-keyword arguments are passed to the job, whereas a single splat will eat additional arguments of either type.

I think this makes for a better doc since people copy-and-pasting are hopefully less likely to end up with a timebomb that could explode in production