### PR TITLE
Automatically use Rails or a default timezone for the schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,9 @@ production:
 
 Tasks are specified as a hash/dictionary, where the key will be the task's key internally. Each task needs to either have a `class`, which will be the job class to enqueue, or a `command`, which will be eval'ed in the context of a job (`SolidQueue::RecurringJob`) that will be enqueued according to its schedule, in the `solid_queue_recurring` queue.
 
-Each task needs to have also a schedule, which is parsed using [Fugit](https://github.com/floraison/fugit), so it accepts anything [that Fugit accepts as a cron](https://github.com/floraison/fugit?tab=readme-ov-file#fugitcron). You can optionally supply the following for each task:
+Each task needs to have also a schedule, which is parsed using [Fugit](https://github.com/floraison/fugit), so it accepts anything [that Fugit accepts as a cron](https://github.com/floraison/fugit?tab=readme-ov-file#fugitcron). Schedules can include a time zone (e.g. `0 9 * * * America/New_York` or `every day at 9am America/New_York`). When a schedule doesn't specify one, it's interpreted in the application's configured time zone (`config.time_zone`) by default. You can change or disable this default with `config.solid_queue.time_zone`; setting it to `nil` falls back to the system's local time.
+
+You can optionally supply the following for each task:
 - `args`: the arguments to be passed to the job, as a single argument, a hash, or an array of arguments that can also include kwargs as the last element in the array.
 
 The job in the example configuration above will be enqueued every second as:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,12 @@
+# Upgrading to version 1.5.x
+Recurring schedules that don't specify a time zone are now interpreted in your application's configured time zone (`config.time_zone`) by default, instead of the system's local time. This only affects schedules without an explicit time zone (e.g. `every day at 9am`); schedules that already include one (e.g. `0 9 * * * America/New_York`) are unaffected.
+
+If your `config.time_zone` differs from the system time where your processes run, recurring jobs may fire at a different wall-clock time than before. To keep the previous behavior, set:
+
+```ruby
+config.solid_queue.time_zone = nil
+```
+
 # Upgrading to version 1.x
 The value returned for `enqueue_after_transaction_commit?` has changed to `true`, and it's no longer configurable. If you want to change this, you need to use Active Job's configuration options.
 

--- a/app/models/solid_queue/recurring_task.rb
+++ b/app/models/solid_queue/recurring_task.rb
@@ -58,15 +58,15 @@ module SolidQueue
 
 
     def next_time_after(time)
-      parsed_schedule.next_time(time).utc
+      parsed_schedule_with_time_zone.next_time(time).utc
     end
 
     def next_time
-      parsed_schedule.next_time.utc
+      parsed_schedule_with_time_zone.next_time.utc
     end
 
     def previous_time
-      parsed_schedule.previous_time.utc
+      parsed_schedule_with_time_zone.previous_time.utc
     end
 
     def last_enqueued_time
@@ -169,9 +169,22 @@ module SolidQueue
         end
       end
 
+      def parsed_schedule_with_time_zone
+        @parsed_schedule_with_time_zone ||= apply_default_time_zone_to(parsed_schedule)
+      end
 
       def parsed_schedule
         @parsed_schedule ||= Fugit.parse(schedule, multi: :fail)
+      end
+
+      def apply_default_time_zone_to(schedule)
+        if schedule.respond_to?(:zone) && schedule.zone.nil? && default_time_zone.present?
+          Fugit.parse("#{schedule.to_cron_s} #{default_time_zone}", multi: :fail)
+        else
+          schedule
+        end
+      rescue ArgumentError
+        schedule
       end
 
       def job_class
@@ -180,6 +193,10 @@ module SolidQueue
 
       def enqueue_options
         { queue: queue_name, priority: priority }.compact
+      end
+
+      def default_time_zone
+        SolidQueue.time_zone
       end
   end
 end

--- a/lib/solid_queue.rb
+++ b/lib/solid_queue.rb
@@ -41,6 +41,15 @@ module SolidQueue
   mattr_accessor :clear_finished_jobs_after, default: 1.day
   mattr_accessor :default_concurrency_control_period, default: 3.minutes
 
+  mattr_reader :time_zone
+
+  def time_zone=(zone)
+    @@time_zone = if zone
+      resolved = zone.respond_to?(:tzinfo) ? zone : ActiveSupport::TimeZone[zone]
+      resolved&.tzinfo&.name || zone.to_s
+    end
+  end
+
   delegate :on_start, :on_stop, :on_exit, to: Supervisor
 
   def schedule_recurring_task(key, **options)

--- a/lib/solid_queue/engine.rb
+++ b/lib/solid_queue/engine.rb
@@ -16,6 +16,12 @@ module SolidQueue
       end
     end
 
+    initializer "solid_queue.time_zone" do |app|
+      unless config.solid_queue.key?(:time_zone)
+        SolidQueue.time_zone = app.config.time_zone
+      end
+    end
+
     initializer "solid_queue.app_executor", before: :run_prepare_callbacks do |app|
       config.solid_queue.app_executor    ||= app.executor
       config.solid_queue.on_thread_error ||= ->(exception) { Rails.error.report(exception, handled: false) }

--- a/test/models/solid_queue/recurring_task_test.rb
+++ b/test/models/solid_queue/recurring_task_test.rb
@@ -272,7 +272,50 @@ class SolidQueue::RecurringTaskTest < ActiveSupport::TestCase
     end
   end
 
+  test "schedule without a time zone uses the configured default time zone" do
+    with_time_zone "America/New_York" do
+      task = recurring_task_with(class_name: "JobWithoutArguments", schedule: "every day at 9am")
+      assert_equal Fugit.parse("0 9 * * * America/New_York").next_time.utc, task.next_time
+    end
+  end
+
+  test "schedule with an explicit time zone ignores the configured default time zone" do
+    with_time_zone "America/New_York" do
+      task = recurring_task_with(class_name: "JobWithoutArguments", schedule: "0 9 * * * Europe/Madrid")
+      assert_equal Fugit.parse("0 9 * * * Europe/Madrid").next_time.utc, task.next_time
+    end
+  end
+
+  test "schedule falls back to local time when no default time zone is configured" do
+    with_time_zone nil do
+      task = recurring_task_with(class_name: "JobWithoutArguments", schedule: "every day at 9am")
+      assert_equal Fugit.parse("0 9 * * *").next_time.utc, task.next_time
+    end
+  end
+
+  test "configured default time zone accepts Rails time zone names" do
+    with_time_zone "Eastern Time (US & Canada)" do
+      task = recurring_task_with(class_name: "JobWithoutArguments", schedule: "every day at 9am")
+      assert_equal Fugit.parse("0 9 * * * America/New_York").next_time.utc, task.next_time
+    end
+  end
+
+  test "default time zone doesn't change the displayed schedule" do
+    with_time_zone "America/New_York" do
+      task = recurring_task_with(class_name: "JobWithoutArguments", schedule: "every day at 9am")
+      assert task.to_s.ends_with? "[ 0 9 * * * ]"
+    end
+  end
+
   private
+    def with_time_zone(zone)
+      previous = SolidQueue.time_zone
+      SolidQueue.time_zone = zone
+      yield
+    ensure
+      SolidQueue.time_zone = previous
+    end
+
     def enqueue_and_assert_performed_with_result(task, result)
       assert_difference [ -> { SolidQueue::Job.count }, -> { SolidQueue::ReadyExecution.count } ], +1 do
         task.enqueue(at: Time.now)

--- a/test/solid_queue_test.rb
+++ b/test/solid_queue_test.rb
@@ -4,4 +4,8 @@ class SolidQueueTest < ActiveSupport::TestCase
   test "it has a version number" do
     assert SolidQueue::VERSION
   end
+
+  test "time_zone defaults to the application's configured time zone, normalized to its IANA name" do
+    assert_equal "Etc/UTC", SolidQueue.time_zone
+  end
 end


### PR DESCRIPTION
Rather than have SolidQueue act on the server configured time, this change allows you to use either the Rails application's current timezone (by default if in a Rails app) or a specified default.