### PR TITLE
Warn instead of raising when the connection pool is smaller than the thread pool

### DIFF
--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -6,7 +6,6 @@ module SolidQueue
 
     validate :ensure_configured_processes
     validate :ensure_valid_recurring_tasks
-    validate :ensure_correctly_sized_thread_pool
 
     class Process < Struct.new(:kind, :attributes)
       def instantiate
@@ -69,6 +68,13 @@ module SolidQueue
       mode.fork? || @options[:standalone]
     end
 
+    def warn_about_undersized_thread_pool
+      if (db_pool_size = SolidQueue::Record.connection_pool&.size) && db_pool_size < estimated_number_of_threads
+        SolidQueue.logger.warn "Solid Queue is configured to use #{estimated_number_of_threads} threads but the " +
+          "database connection pool is #{db_pool_size}. Increase it in `config/database.yml`"
+      end
+    end
+
     private
       attr_reader :options
 
@@ -85,13 +91,6 @@ module SolidQueue
           end
 
           errors.add(:base, "Invalid recurring tasks:\n#{error_messages.join("\n")}")
-        end
-      end
-
-      def ensure_correctly_sized_thread_pool
-        if (db_pool_size = SolidQueue::Record.connection_pool&.size) && db_pool_size < estimated_number_of_threads
-          errors.add(:base, "Solid Queue is configured to use #{estimated_number_of_threads} threads but the " +
-            "database connection pool is #{db_pool_size}. Increase it in `config/database.yml`")
         end
       end
 

--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -13,6 +13,8 @@ module SolidQueue
         configuration = Configuration.new(**options)
 
         if configuration.valid?
+          configuration.warn_about_undersized_thread_pool
+
           klass = configuration.mode.fork? ? ForkSupervisor : AsyncSupervisor
           klass.new(configuration).tap(&:start)
         else

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -165,14 +165,29 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_not configuration.valid?
     assert_equal [ "No processes configured" ], configuration.errors.full_messages
 
-    # Not enough DB connections
+    # Not enough DB connections: still valid so boot is not blocked
     configuration = SolidQueue::Configuration.new(workers: [ { queues: "background", threads: 50, polling_interval: 10 } ])
-    assert_not configuration.valid?
-    assert_match /Solid Queue is configured to use \d+ threads but the database connection pool is \d+. Increase it in `config\/database.yml`/,
-      configuration.errors.full_messages.first
+    assert configuration.valid?
+  end
+
+  test "warns on boot when the database pool is smaller than the thread pool" do
+    log = StringIO.new
+    with_solid_queue_logger(ActiveSupport::Logger.new(log)) do
+      configuration = SolidQueue::Configuration.new(workers: [ { queues: "background", threads: 50, polling_interval: 10 } ])
+      configuration.warn_about_undersized_thread_pool
+    end
+
+    assert_match /Solid Queue is configured to use \d+ threads but the database connection pool is \d+\. Increase it in `config\/database.yml`/, log.string
   end
 
   private
+    def with_solid_queue_logger(logger)
+      old_logger, SolidQueue.logger = SolidQueue.logger, logger
+      yield
+    ensure
+      SolidQueue.logger = old_logger
+    end
+
     def assert_processes(configuration, kind, count, **attributes)
       processes = configuration.configured_processes.select { |p| p.kind == kind }
       assert_equal count, processes.size


### PR DESCRIPTION
Solid Queue currently refuses to boot when the Active Record connection pool is smaller than the worker thread pool, raising a configuration validation error. This blocks legitimate setups such as I/O-bound queues that run many threads against a deliberately small pool.

This downgrades the check from a validation error to a `SolidQueue.logger` warning. The warning is emitted once on the boot path in `Supervisor.start`, after the configuration is confirmed valid, so undersized configurations boot and run while still surfacing the advisory. `Configuration#valid?` stays purely about whether we can boot.

The original message wording is retained, just at `warn` level.

Closes #736