### PR TITLE
Warn instead of raising when the connection pool is smaller than the thread pool

### DIFF
--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -6,7 +6,6 @@ module SolidQueue
 
     validate :ensure_configured_processes
     validate :ensure_valid_recurring_tasks
-    validate :ensure_correctly_sized_thread_pool
 
     class Process < Struct.new(:kind, :attributes)
       def instantiate
@@ -69,6 +68,13 @@ module SolidQueue
       mode.fork? || @options[:standalone]
     end
 
+    def warn_about_undersized_thread_pool
+      if (db_pool_size = SolidQueue::Record.connection_pool&.size) && db_pool_size < estimated_number_of_threads
+        SolidQueue.logger.warn "Solid Queue is configured to use #{estimated_number_of_threads} threads but the " +
+          "database connection pool is #{db_pool_size}. Increase it in `config/database.yml`"
+      end
+    end
+
     private
       attr_reader :options
 
@@ -85,13 +91,6 @@ module SolidQueue
           end
 
           errors.add(:base, "Invalid recurring tasks:\n#{error_messages.join("\n")}")
-        end
-      end
-
-      def ensure_correctly_sized_thread_pool
-        if (db_pool_size = SolidQueue::Record.connection_pool&.size) && db_pool_size < estimated_number_of_threads
-          errors.add(:base, "Solid Queue is configured to use #{estimated_number_of_threads} threads but the " +
-            "database connection pool is #{db_pool_size}. Increase it in `config/database.yml`")
         end
       end
 

--- a/lib/solid_queue/supervisor.rb
+++ b/lib/solid_queue/supervisor.rb
@@ -13,6 +13,8 @@ module SolidQueue
         configuration = Configuration.new(**options)
 
         if configuration.valid?
+          configuration.warn_about_undersized_thread_pool
+
           klass = configuration.mode.fork? ? ForkSupervisor : AsyncSupervisor
           klass.new(configuration).tap(&:start)
         else

--- a/test/unit/async_supervisor_test.rb
+++ b/test/unit/async_supervisor_test.rb
@@ -84,9 +84,40 @@ class AsyncSupervisorTest < ActiveSupport::TestCase
     end
   end
 
+  test "warns on boot when the thread pool is larger than the database connection pool" do
+    log = StringIO.new
+    with_solid_queue_logger(ActiveSupport::Logger.new(log)) do
+      supervisor = run_supervisor_as_thread(workers: [ { queues: "background", threads: 50, polling_interval: 10 } ], dispatchers: [])
+      wait_for_registered_processes(2, timeout: 3.seconds) # supervisor + 1 worker
+    ensure
+      supervisor.stop
+    end
+
+    assert_match /Solid Queue is configured to use \d+ threads but the database connection pool is \d+\. Increase it in `config\/database.yml`/, log.string
+  end
+
+  test "does not warn on boot when the database connection pool is large enough" do
+    log = StringIO.new
+    with_solid_queue_logger(ActiveSupport::Logger.new(log)) do
+      supervisor = run_supervisor_as_thread(workers: [ { queues: "background", threads: 1, polling_interval: 10 } ], dispatchers: [])
+      wait_for_registered_processes(2, timeout: 3.seconds) # supervisor + 1 worker
+    ensure
+      supervisor.stop
+    end
+
+    assert_no_match /the database connection pool is/, log.string
+  end
+
   private
     def run_supervisor_as_thread(**options)
       SolidQueue::Supervisor.start(mode: :async, standalone: false, **options.with_defaults(skip_recurring: true))
+    end
+
+    def with_solid_queue_logger(logger)
+      old_logger, SolidQueue.logger = SolidQueue.logger, logger
+      yield
+    ensure
+      SolidQueue.logger = old_logger
     end
 
     def simulate_orphaned_executions(count)

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -165,14 +165,29 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_not configuration.valid?
     assert_equal [ "No processes configured" ], configuration.errors.full_messages
 
-    # Not enough DB connections
+    # Not enough DB connections: still valid so boot is not blocked
     configuration = SolidQueue::Configuration.new(workers: [ { queues: "background", threads: 50, polling_interval: 10 } ])
-    assert_not configuration.valid?
-    assert_match /Solid Queue is configured to use \d+ threads but the database connection pool is \d+. Increase it in `config\/database.yml`/,
-      configuration.errors.full_messages.first
+    assert configuration.valid?
+  end
+
+  test "warns on boot when the database pool is smaller than the thread pool" do
+    log = StringIO.new
+    with_solid_queue_logger(ActiveSupport::Logger.new(log)) do
+      configuration = SolidQueue::Configuration.new(workers: [ { queues: "background", threads: 50, polling_interval: 10 } ])
+      configuration.warn_about_undersized_thread_pool
+    end
+
+    assert_match /Solid Queue is configured to use \d+ threads but the database connection pool is \d+\. Increase it in `config\/database.yml`/, log.string
   end
 
   private
+    def with_solid_queue_logger(logger)
+      old_logger, SolidQueue.logger = SolidQueue.logger, logger
+      yield
+    ensure
+      SolidQueue.logger = old_logger
+    end
+
     def assert_processes(configuration, kind, count, **attributes)
       processes = configuration.configured_processes.select { |p| p.kind == kind }
       assert_equal count, processes.size


### PR DESCRIPTION
## What

Solid Queue refuses to boot when the database connection pool is smaller than the worker thread pool, raising a `ConfigurationError`. This PR makes the check advisory: Solid Queue boots and logs a warning instead.

## Why

The hard cap rules out configurations that work well in practice. The reporter in #736 runs an I/O-bound queue — 150 threads making slow HTTP calls against a deliberately small pool — where each thread holds a connection only briefly. Today, booting that setup requires monkey-patching the check away.

As suggested in #736, this replaces the hard failure with a warning, which the reporter confirmed fits the need. (The issue also floated a config flag to bypass the check; an unconditional warning is simpler and adds no new configuration surface.)

## How

- Drop `ensure_correctly_sized_thread_pool` from the validation chain, so `Configuration#valid?` reflects only whether the configuration can boot.
- Add `Configuration#warn_about_undersized_thread_pool`, which logs the advisory through `SolidQueue.logger`.
- Call it from `Supervisor.start`, just after the `valid?` check. The `bin/jobs` CLI and both Puma plugin modes — forked and async — start through `Supervisor.start`, so the warning fires once on every boot path.

The warning text matches the previous error, so existing log filters and operator expectations still hold.

## Tests

- `async_supervisor_test`: booting with more threads than connections logs the warning; booting with enough connections stays silent. (Removing the call from `Supervisor.start` fails the first test.)
- `configuration_test`: an undersized pool no longer makes the configuration invalid.

Closes #736.
