### PR TITLE
Report rescued recurring enqueue errors to Rails.error

### DIFF
--- a/app/models/solid_queue/recurring_task.rb
+++ b/app/models/solid_queue/recurring_task.rb
@@ -86,6 +86,7 @@ module SolidQueue
 
           perform_later.tap do |job|
             unless job.successfully_enqueued?
+              report_enqueue_error(job.enqueue_error, at: at)
               payload[:enqueue_error] = job.enqueue_error&.message
             end
           end
@@ -98,6 +99,7 @@ module SolidQueue
         payload[:skipped] = true
         false
       rescue Job::EnqueueError => error
+        report_enqueue_error(error, at: at)
         payload[:enqueue_error] = error.message
         false
       end
@@ -197,6 +199,12 @@ module SolidQueue
 
       def default_time_zone
         SolidQueue.time_zone
+      end
+
+      def report_enqueue_error(error, at:)
+        if error
+          Rails.error.report(error, handled: true, source: "application.solid_queue", context: { task: key, at: at })
+        end
       end
   end
 end

--- a/test/models/solid_queue/recurring_task_test.rb
+++ b/test/models/solid_queue/recurring_task_test.rb
@@ -307,6 +307,46 @@ class SolidQueue::RecurringTaskTest < ActiveSupport::TestCase
     end
   end
 
+  test "reports Job::EnqueueError to Rails.error when enqueuing via Solid Queue" do
+    SolidQueue::Job.stubs(:create!).raises(ActiveRecord::Deadlocked)
+    subscriber = ErrorBuffer.new
+    at = Time.now
+
+    with_error_subscriber(subscriber) do
+      task = recurring_task_with(class_name: "JobWithoutArguments")
+      task.enqueue(at: at)
+    end
+
+    assert_equal 1, subscriber.errors.count
+    error, options = subscriber.errors.first
+    assert_kind_of SolidQueue::Job::EnqueueError, error
+    assert_match "ActiveRecord::Deadlocked", error.message
+    assert_equal true, options[:handled]
+    assert_equal "application.solid_queue", options[:source]
+    assert_equal "task-id", options[:context][:task]
+    assert_equal at, options[:context][:at]
+  end
+
+  test "reports enqueue error to Rails.error when using another adapter" do
+    ActiveJob::QueueAdapters::AsyncAdapter.any_instance.stubs(:enqueue).raises(ActiveJob::EnqueueError.new("All is broken"))
+    subscriber = ErrorBuffer.new
+    at = Time.now
+
+    with_error_subscriber(subscriber) do
+      task = recurring_task_with(class_name: "JobUsingAsyncAdapter")
+      task.enqueue(at: at)
+    end
+
+    assert_equal 1, subscriber.errors.count
+    error, options = subscriber.errors.first
+    assert_kind_of ActiveJob::EnqueueError, error
+    assert_equal "All is broken", error.message
+    assert_equal true, options[:handled]
+    assert_equal "application.solid_queue", options[:source]
+    assert_equal "task-id", options[:context][:task]
+    assert_equal at, options[:context][:at]
+  end
+
   private
     def with_time_zone(zone)
       previous = SolidQueue.time_zone
@@ -343,5 +383,12 @@ class SolidQueue::RecurringTaskTest < ActiveSupport::TestCase
         worker.mode = :inline
         worker.start
       end
+    end
+
+    def with_error_subscriber(subscriber)
+      Rails.error.subscribe(subscriber)
+      yield
+    ensure
+      Rails.error.unsubscribe(subscriber) if Rails.error.respond_to?(:unsubscribe)
     end
 end


### PR DESCRIPTION
## Summary
- When `RecurringTask#enqueue` rescues `Job::EnqueueError` (or an other-adapter enqueue failure), report the exception via `Rails.error.report` so error subscribers (Sentry, etc.) see it.
- Keeps the existing non-bubbling behavior (`handled: true`) and notification payload shape.
- Fixes a production gap where DB write failures during recurring enqueue only produced log lines / Mission Control “Missed” ticks, with no Issue.

Fixes #746

## Test plan
- [x] `bin/rails test test/models/solid_queue/recurring_task_test.rb`
- [x] Recurring enqueue instrumentation tests still pass
- [ ] Confirm a Sentry (or other `Rails.error` subscriber) receives the original exception object with cause/backtrace during a simulated enqueue failure


Made with [Cursor](https://cursor.com)