### PR TITLE
Add --only-recurring to run just the recurring scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ bin/jobs -c config/calendar.yml
 
 You can also skip the scheduler process by setting the environment variable `SOLID_QUEUE_SKIP_RECURRING=true`. This is useful for environments like staging, review apps, or development where you don't want any recurring jobs to run. This is equivalent to using the `--skip-recurring` option with `bin/jobs`.
 
+To run **only** the scheduler (no workers or dispatchers)—for example to isolate recurring tasks on a dedicated process—set `SOLID_QUEUE_ONLY_RECURRING=true` or use the `--only-recurring` option with `bin/jobs`.
+
 This is what this configuration looks like:
 
 ```yml
@@ -708,6 +710,8 @@ bin/jobs --recurring_schedule_file=config/schedule.yml
 ```
 
 You can completely disable recurring tasks by setting the environment variable `SOLID_QUEUE_SKIP_RECURRING=true` or by using the `--skip-recurring` option with `bin/jobs`.
+
+To run only the scheduler (no workers or dispatchers), set `SOLID_QUEUE_ONLY_RECURRING=true` or use `--only-recurring` with `bin/jobs`.
 
 The configuration itself looks like this:
 

--- a/lib/solid_queue/cli.rb
+++ b/lib/solid_queue/cli.rb
@@ -20,6 +20,10 @@ module SolidQueue
       desc: "Whether to skip recurring tasks scheduling",
       banner: "SOLID_QUEUE_SKIP_RECURRING"
 
+    class_option :only_recurring, type: :boolean,
+      desc: "Whether to run only the scheduler process for recurring tasks",
+      banner: "SOLID_QUEUE_ONLY_RECURRING"
+
     def self.exit_on_failure?
       true
     end

--- a/lib/solid_queue/configuration.rb
+++ b/lib/solid_queue/configuration.rb
@@ -43,7 +43,10 @@ module SolidQueue
     end
 
     def configured_processes
-      if only_work? then workers
+      if only_work?
+        workers
+      elsif only_recurring?
+        schedulers
       else
         dispatchers + workers + schedulers
       end
@@ -126,6 +129,7 @@ module SolidQueue
           recurring_schedule_file: Rails.root.join(ENV["SOLID_QUEUE_RECURRING_SCHEDULE"] || DEFAULT_RECURRING_SCHEDULE_FILE_PATH),
           only_work: false,
           only_dispatch: false,
+          only_recurring: ActiveModel::Type::Boolean.new.cast(ENV["SOLID_QUEUE_ONLY_RECURRING"]),
           skip_recurring: ActiveModel::Type::Boolean.new.cast(ENV["SOLID_QUEUE_SKIP_RECURRING"])
         }
       end
@@ -140,6 +144,10 @@ module SolidQueue
 
       def only_dispatch?
         options[:only_dispatch]
+      end
+
+      def only_recurring?
+        options[:only_recurring]
       end
 
       def skip_recurring_tasks?

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -36,6 +36,22 @@ class CliTest < ActiveSupport::TestCase
     end
   end
 
+  test "only_recurring option runs just the scheduler" do
+    config = configuration_from_cli(only_recurring: true)
+
+    assert_equal 1, config.configured_processes.count
+    assert_equal :scheduler, config.configured_processes.first.kind
+  end
+
+  test "only_recurring respects SOLID_QUEUE_ONLY_RECURRING env var" do
+    with_env("SOLID_QUEUE_ONLY_RECURRING" => "true") do
+      config = configuration_from_cli
+
+      assert_equal 1, config.configured_processes.count
+      assert_equal :scheduler, config.configured_processes.first.kind
+    end
+  end
+
   test "check exits 0 and prints OK message for a valid configuration" do
     out, err = capture_io do
       assert_nothing_raised { SolidQueue::Cli.start([ "check", "--skip-recurring" ]) }

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -111,6 +111,45 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_processes configuration, :dispatcher, 1, polling_interval: 0.1, recurring_tasks: nil
   end
 
+  test "only_recurring runs just the scheduler process" do
+    configuration = SolidQueue::Configuration.new(only_recurring: true)
+
+    assert_equal 1, configuration.configured_processes.count
+    assert_processes configuration, :scheduler, 1
+    assert_processes configuration, :worker, 0
+    assert_processes configuration, :dispatcher, 0
+    assert configuration.valid?
+  end
+
+  test "only_recurring ignores workers and dispatchers from the config file" do
+    configuration = SolidQueue::Configuration.new(only_recurring: true)
+
+    assert_processes configuration, :worker, 0
+    assert_processes configuration, :dispatcher, 0
+    assert_processes configuration, :scheduler, 1
+
+    scheduler = configuration.configured_processes.first.instantiate
+    assert_has_recurring_task scheduler, key: "periodic_store_result", class_name: "StoreResultJob", schedule: "every second"
+  end
+
+  test "only_recurring when SOLID_QUEUE_ONLY_RECURRING environment variable is set" do
+    with_env("SOLID_QUEUE_ONLY_RECURRING" => "true") do
+      configuration = SolidQueue::Configuration.new
+
+      assert_equal 1, configuration.configured_processes.count
+      assert_processes configuration, :scheduler, 1
+      assert_processes configuration, :worker, 0
+      assert_processes configuration, :dispatcher, 0
+    end
+  end
+
+  test "only_recurring with skip_recurring is invalid" do
+    configuration = SolidQueue::Configuration.new(only_recurring: true, skip_recurring: true)
+
+    assert_not configuration.valid?
+    assert_equal [ "No processes configured" ], configuration.errors.full_messages
+  end
+
   test "skip recurring tasks when SOLID_QUEUE_SKIP_RECURRING environment variable is set" do
     with_env("SOLID_QUEUE_SKIP_RECURRING" => "true") do
       configuration = SolidQueue::Configuration.new(dispatchers: [ { polling_interval: 0.1 } ])


### PR DESCRIPTION
## Summary
- Adds `--only-recurring` / `SOLID_QUEUE_ONLY_RECURRING` so `bin/jobs` can run only the recurring scheduler (no workers or dispatchers).
- Mirrors the existing `--skip-recurring` opt-out and replaces the empty workers/dispatchers config workaround.
- Documents the option in the README.

Fixes #484

## Test plan
- [x] `bin/rails test test/unit/configuration_test.rb test/unit/cli_test.rb`
- [ ] Manually: `bin/jobs --only-recurring` registers only a Scheduler process
- [ ] Manually: `SOLID_QUEUE_ONLY_RECURRING=true bin/jobs` behaves the same