### PR TITLE
Prevent concurrency lock leaks that cause duplicate job execution

### DIFF
--- a/app/models/solid_queue/claimed_execution.rb
+++ b/app/models/solid_queue/claimed_execution.rb
@@ -43,7 +43,6 @@ class SolidQueue::ClaimedExecution < SolidQueue::Execution
         SolidQueue.instrument(:fail_many_claimed) do |payload|
           executions.each do |execution|
             execution.failed_with(error)
-            execution.unblock_next_job
           end
 
           payload[:process_ids] = executions.map(&:process_id).uniq
@@ -71,13 +70,11 @@ class SolidQueue::ClaimedExecution < SolidQueue::Execution
       failed_with(result.error)
       raise result.error
     end
-  ensure
-    unblock_next_job
   end
 
   def release
     SolidQueue.instrument(:release_claimed, job_id: job.id, process_id: process_id) do
-      transaction do
+      unless_already_finalized do
         job.dispatch_bypassing_concurrency_limits
         destroy!
       end
@@ -89,14 +86,7 @@ class SolidQueue::ClaimedExecution < SolidQueue::Execution
   end
 
   def failed_with(error)
-    transaction do
-      job.failed_with(error)
-      destroy!
-    end
-  end
-
-  def unblock_next_job
-    job.unblock_next_blocked_job
+    finalize { job.failed_with(error) }
   end
 
   private
@@ -108,9 +98,28 @@ class SolidQueue::ClaimedExecution < SolidQueue::Execution
     end
 
     def finished
-      transaction do
-        job.finished!
+      finalize { job.finished! }
+    end
+
+    def finalize
+      finalized = unless_already_finalized do
+        yield
         destroy!
+        true
+      end
+
+      # Unblock the next job outside the finalize transaction so a failure while
+      # releasing the concurrency lock or dispatching the next job can't roll back
+      # a job that already finished or failed. Only the actor that owned and
+      # finalized the claim gets here, so the lock is released exactly once.
+      job.unblock_next_blocked_job if finalized
+    end
+
+    def unless_already_finalized
+      transaction do
+        return false unless self.class.unscoped.lock.find_by(id: id)
+
+        yield
       end
     end
 end

--- a/app/models/solid_queue/semaphore.rb
+++ b/app/models/solid_queue/semaphore.rb
@@ -32,7 +32,13 @@ module SolidQueue
 
     class Proxy
       def self.signal_all(jobs)
-        Semaphore.where(key: jobs.map(&:concurrency_key)).update_all("value = value + 1")
+        # Guard against incrementing a semaphore's value beyond its limit. Jobs can
+        # have different limits, so group them and cap each group with `value < limit`.
+        jobs.group_by { |job| job.concurrency_limit || 1 }.each do |limit, grouped_jobs|
+          Semaphore.where(key: grouped_jobs.map(&:concurrency_key))
+            .where(value: ...limit)
+            .update_all("value = value + 1")
+        end
       end
 
       def initialize(job)

--- a/test/models/solid_queue/claimed_execution_concurrency_test.rb
+++ b/test/models/solid_queue/claimed_execution_concurrency_test.rb
@@ -1,0 +1,228 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# These tests exercise the real FOR UPDATE serialization in ClaimedExecution's
+# finalization, so they run on separate connections/threads and skip on SQLite,
+# which has no row-level locking. They follow the same pattern as
+# SolidQueue::SemaphoreTest.
+class SolidQueue::ClaimedExecutionConcurrencyTest < ActiveSupport::TestCase
+  self.use_transactional_tests = false
+
+  setup do
+    @process = SolidQueue::Process.register(kind: "Worker", pid: 42, name: "worker-123")
+  end
+
+  test "a stale performer that loses the claim lock to pruning does not finish or re-promote a pruned job" do
+    skip_on_sqlite
+
+    first_job, claimed_execution, concurrency_key = enqueue_blocked_group
+
+    elapsed = with_winner_holding_claim(claimed_execution,
+      in_transaction: ->(locked_claim) do
+        first_job.failed_with(SolidQueue::Processes::ProcessPrunedError.new(1.day.ago))
+        locked_claim.destroy!
+      end,
+      after_commit: -> { first_job.unblock_next_blocked_job }) do
+      claimed_execution.perform
+    end
+
+    assert_operator elapsed, :>=, 0.3, "performer should have blocked on the claim lock (took #{elapsed.round(3)}s)"
+    assert first_job.reload.failed?
+    assert_not first_job.finished?
+    assert_equal 1, SolidQueue::ReadyExecution.count
+    assert_equal 1, SolidQueue::BlockedExecution.count
+    assert_equal 0, SolidQueue::ClaimedExecution.count
+    assert_equal 0, SolidQueue::Semaphore.find_by!(key: concurrency_key).value
+  end
+
+  test "a stale failing performer that loses the claim lock to pruning does not double-finalize" do
+    skip_on_sqlite
+
+    first_job, claimed_execution, concurrency_key = enqueue_blocked_group(exception: RuntimeError)
+
+    elapsed = with_winner_holding_claim(claimed_execution,
+      in_transaction: ->(locked_claim) do
+        first_job.failed_with(SolidQueue::Processes::ProcessPrunedError.new(1.day.ago))
+        locked_claim.destroy!
+      end,
+      after_commit: -> { first_job.unblock_next_blocked_job }) do
+      assert_raises(RuntimeError) { claimed_execution.perform }
+    end
+
+    assert_operator elapsed, :>=, 0.3, "performer should have blocked on the claim lock (took #{elapsed.round(3)}s)"
+    assert first_job.reload.failed?
+    assert_equal 1, SolidQueue::ReadyExecution.count
+    assert_equal 1, SolidQueue::BlockedExecution.count
+    assert_equal 1, SolidQueue::FailedExecution.count
+    assert_equal 0, SolidQueue::ClaimedExecution.count
+    assert_equal 0, SolidQueue::Semaphore.find_by!(key: concurrency_key).value
+  end
+
+  test "a stale release that loses the claim lock to pruning does not re-dispatch a pruned job" do
+    skip_on_sqlite
+
+    first_job, claimed_execution, concurrency_key = enqueue_blocked_group
+
+    elapsed = with_winner_holding_claim(claimed_execution,
+      in_transaction: ->(locked_claim) do
+        first_job.failed_with(SolidQueue::Processes::ProcessPrunedError.new(1.day.ago))
+        locked_claim.destroy!
+      end,
+      after_commit: -> { first_job.unblock_next_blocked_job }) do
+      claimed_execution.release
+    end
+
+    assert_operator elapsed, :>=, 0.3, "release should have blocked on the claim lock (took #{elapsed.round(3)}s)"
+    assert first_job.reload.failed?
+    assert_not first_job.ready?
+    assert_equal 1, SolidQueue::ReadyExecution.count
+    assert_equal 1, SolidQueue::BlockedExecution.count
+    assert_equal 0, SolidQueue::ClaimedExecution.count
+    assert_equal 0, SolidQueue::Semaphore.find_by!(key: concurrency_key).value
+  end
+
+  test "pruning that loses the claim lock to a finishing performer does not fail a finished job" do
+    skip_on_sqlite
+
+    first_job, claimed_execution, concurrency_key = enqueue_blocked_group
+
+    elapsed = with_winner_holding_claim(claimed_execution,
+      in_transaction: ->(locked_claim) do
+        first_job.finished!
+        locked_claim.destroy!
+      end,
+      after_commit: -> { first_job.unblock_next_blocked_job }) do
+      @process.prune
+    end
+
+    assert_operator elapsed, :>=, 0.3, "pruning should have blocked on the claim lock (took #{elapsed.round(3)}s)"
+    assert first_job.reload.finished?
+    assert_not first_job.failed?
+    assert_equal 1, SolidQueue::ReadyExecution.count
+    assert_equal 1, SolidQueue::BlockedExecution.count
+    assert_equal 0, SolidQueue::FailedExecution.count
+    assert_equal 0, SolidQueue::ClaimedExecution.count
+    assert_equal 0, SolidQueue::Semaphore.find_by!(key: concurrency_key).value
+  end
+
+  test "finalizing a claim does not deadlock a concurrent blocked-job release when skip_locked is off" do
+    skip_on_sqlite
+
+    with_skip_locked(false) do
+      first_job, claimed_execution, concurrency_key = enqueue_blocked_group
+      blocked_execution = SolidQueue::BlockedExecution.first
+
+      holding_blocked_row = Concurrent::Event.new
+      release_blocked_row = Concurrent::Event.new
+
+      # Mimic the normal release path's lock order: lock the blocked row first,
+      # then contend for the semaphore. Held open so finalize must run alongside it.
+      releaser = Thread.new do
+        SolidQueue::Record.connection_pool.with_connection do
+          SolidQueue::Record.transaction do
+            SolidQueue::BlockedExecution.where(id: blocked_execution.id).lock.first
+            holding_blocked_row.set
+            release_blocked_row.wait(5)
+            SolidQueue::Semaphore.where(key: concurrency_key).lock.first
+          end
+        end
+      end
+
+      holding_blocked_row.wait(5)
+
+      # finalize releases the concurrency lock and commits before it tries to
+      # release the next blocked job, so it never holds the semaphore lock while
+      # waiting on the blocked row. Releasing the blocked job inside the claim
+      # transaction would reverse the lock order and could deadlock.
+      assert_nothing_raised do
+        Timeout.timeout(10) do
+          finisher = Thread.new do
+            SolidQueue::Record.connection_pool.with_connection do
+              claimed_execution.send(:finished)
+            end
+          end
+
+          # Give finalize time to commit its semaphore signal, then let the
+          # releaser reach for the semaphore.
+          sleep 0.5
+          release_blocked_row.set
+          finisher.join(10)
+        end
+      end
+
+      releaser.join(10)
+
+      assert first_job.reload.finished?
+      assert_equal 0, SolidQueue::ClaimedExecution.count
+    end
+  end
+
+  private
+    # Enqueues three concurrency-limited jobs over the same key. The first is
+    # claimed; the other two are blocked. Returns the first job, its claimed
+    # execution, and the shared concurrency key.
+    def enqueue_blocked_group(exception: nil)
+      job_result = JobResult.create!(queue_name: "default", status: "")
+      first_active_job = NonOverlappingUpdateResultJob.perform_later(job_result, name: "A", exception: exception)
+      NonOverlappingUpdateResultJob.perform_later(job_result, name: "B")
+      NonOverlappingUpdateResultJob.perform_later(job_result, name: "C")
+
+      first_job = SolidQueue::Job.find_by!(active_job_id: first_active_job.job_id)
+      claimed_execution = claim_first_job(first_job)
+
+      [ first_job, claimed_execution, first_job.concurrency_key ]
+    end
+
+    def claim_first_job(job)
+      SolidQueue::ReadyExecution.claim(job.queue_name, 1, @process.id)
+      SolidQueue::ClaimedExecution.find_by!(job_id: job.id)
+    end
+
+    # Runs the given block (the stale worker's action) while a separate connection
+    # holds the claim's FOR UPDATE lock, then finishes the claim first and commits.
+    # The stale worker must block on the lock and, once it resumes, find the claim
+    # gone. Returns how long the stale worker was blocked.
+    def with_winner_holding_claim(claimed_execution, in_transaction:, after_commit: nil)
+      claim_locked = Concurrent::Event.new
+
+      winner = Thread.new do
+        SolidQueue::Record.connection_pool.with_connection do
+          SolidQueue::Record.transaction do
+            locked_claim = SolidQueue::ClaimedExecution.unscoped.lock.find_by(id: claimed_execution.id)
+            claim_locked.set
+            sleep 0.5
+            in_transaction.call(locked_claim)
+          end
+
+          after_commit&.call
+        end
+      end
+
+      claim_locked.wait(5)
+      sleep 0.1
+
+      started_at = monotonic_now
+      yield
+      elapsed = monotonic_now - started_at
+
+      winner.join(5)
+      elapsed
+    end
+
+    def with_skip_locked(value)
+      previous = SolidQueue.use_skip_locked
+      SolidQueue.use_skip_locked = value
+      yield
+    ensure
+      SolidQueue.use_skip_locked = previous
+    end
+
+    def skip_on_sqlite
+      skip "Row-level locking not supported on SQLite" if SolidQueue::Record.connection.adapter_name.downcase.include?("sqlite")
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+end

--- a/test/models/solid_queue/claimed_execution_test.rb
+++ b/test/models/solid_queue/claimed_execution_test.rb
@@ -17,6 +17,29 @@ class SolidQueue::ClaimedExecutionTest < ActiveSupport::TestCase
     assert job.reload.finished?
   end
 
+  test "stale performer cannot release a concurrency lock after its claim is pruned" do
+    job_result = JobResult.create!(queue_name: "default", status: "")
+    first_active_job = NonOverlappingUpdateResultJob.perform_later(job_result, name: "A")
+    NonOverlappingUpdateResultJob.perform_later(job_result, name: "B")
+    NonOverlappingUpdateResultJob.perform_later(job_result, name: "C")
+
+    first_job = SolidQueue::Job.find_by!(active_job_id: first_active_job.job_id)
+    claimed_execution = claim_job(first_job)
+    @process.prune
+
+    assert first_job.reload.failed?
+    assert_equal 1, SolidQueue::ReadyExecution.count
+    assert_equal 1, SolidQueue::BlockedExecution.count
+
+    claimed_execution.perform
+
+    assert_not first_job.reload.finished?
+    assert first_job.failed?
+    assert_equal 1, SolidQueue::ReadyExecution.count
+    assert_equal 1, SolidQueue::BlockedExecution.count
+    assert_equal 0, SolidQueue::Semaphore.find_by!(key: first_job.concurrency_key).value
+  end
+
   test "perform job that fails" do
     claimed_execution = prepare_and_claim_job RaisingJob.perform_later(RuntimeError, "A")
     job = claimed_execution.job

--- a/test/models/solid_queue/semaphore_test.rb
+++ b/test/models/solid_queue/semaphore_test.rb
@@ -108,6 +108,40 @@ class SolidQueue::SemaphoreTest < ActiveSupport::TestCase
     assert_equal 0, SolidQueue::BlockedExecution.where(concurrency_key: concurrency_key).count
   end
 
+  test "signal_all does not increment semaphore value beyond limit" do
+    # Create a job with concurrency limit of 1
+    NonOverlappingUpdateResultJob.perform_later(@result)
+    job = SolidQueue::Job.last
+    concurrency_key = job.concurrency_key
+
+    # Semaphore should exist with value=0 (one slot taken)
+    semaphore = SolidQueue::Semaphore.find_by(key: concurrency_key)
+    assert_equal 0, semaphore.value
+
+    # Manually set semaphore to its limit (simulating the slot was already returned)
+    semaphore.update!(value: 1)
+
+    # signal_all should NOT increment beyond the limit
+    SolidQueue::Semaphore.signal_all([ job ])
+
+    assert_equal 1, semaphore.reload.value, "signal_all should not increment semaphore beyond its limit"
+  end
+
+  test "signal_all increments semaphore when below limit" do
+    # Create a job with concurrency limit of 1
+    NonOverlappingUpdateResultJob.perform_later(@result)
+    job = SolidQueue::Job.last
+    concurrency_key = job.concurrency_key
+
+    # Semaphore should exist with value=0
+    assert_equal 0, SolidQueue::Semaphore.find_by(key: concurrency_key).value
+
+    # signal_all should increment from 0 to 1
+    SolidQueue::Semaphore.signal_all([ job ])
+
+    assert_equal 1, SolidQueue::Semaphore.find_by(key: concurrency_key).value
+  end
+
   private
     def skip_on_sqlite
       skip "Row-level locking not supported on SQLite" if SolidQueue::Record.connection.adapter_name.downcase.include?("sqlite")


### PR DESCRIPTION
Supersedes #689 and ports the exact-once fix from [starburstlabs/solid_queue#11](https://github.com/starburstlabs/solid_queue/pull/11). Both target the same failure: a job with `limits_concurrency` whose semaphore count gets permanently corrupted, letting it run well past its configured limit.

## Background

Two independent reports converged on the same class of bug:

- **#689** (@mhenrixon) — duplicate execution despite `limits_concurrency`.
- **starburstlabs#11** (@tblais1224) — a production incident where a `limit: 1` job ran 11× concurrently after a transient heartbeat failure.

The failure: a worker stays alive on a long-running job but its DB heartbeat fails transiently. Another supervisor prunes it as dead — failing its claimed execution, releasing its concurrency lock, and unblocking a replacement — but the original execution keeps running. When it finally returns, its stale `ClaimedExecution` finalizes the job and releases the **same lock a second time**, pushing the semaphore value above its limit and admitting ever more concurrent work.

## Changes

**1. Guard `signal_all` against exceeding the limit** (from #689, @mhenrixon)

`Semaphore#signal` already caps its increment with `value < limit`, but the batch `signal_all` path — used when releasing concurrency locks in bulk, e.g. discarding ready jobs — did not, letting a semaphore's value climb past its limit. It's now grouped by limit and capped, matching the single-signal path.

**2. Prevent wrong release of blocked jobs and semaphore corruption** (from starburstlabs#11, @tblais1224 & @briceburg-wb)

The problem: a worker stays alive on a long-running job but its database heartbeat fails transiently. Another supervisor prunes it as dead, fails its claimed execution, releases its concurrency lock, and unblocks a replacement — but the original execution keeps running. When it finally returns, its stale `ClaimedExecution`, which exists only in memory, because the DB record was deleted by the supervisor prune, also goes through the semaphore and blocked execution release, potentially violating the limit and allowing more concurrent jobs.

With this change, we take a lock on the claimed execution row so that it's required that it still exists and we're the only ones acting over it, before running the finalization code: deleting the claimed execution row, signaling the semaphore and unblocking blocked jobs. In the scenario described above, we'd see the claimed execution record as gone and would do nothing.

Note that the semaphore signal + blocked jobs release is still done after the transaction that marks the job as finished/failed, so that these two actions can't rollback a job that finished/failed (see 873760d). Because this can only happen for the ones who got to clear the claimed execution row, we still guarantee the lock is released just once.
 

## Scope

- From #689, only the `signal_all` guard is taken. Its other changes were dropped: not releasing blocked jobs while a same-key job runs (existing, expected behavior); the `FOR UPDATE` lock in `Semaphore#wait` (already on `main` in 8d90eab, #456); and the `release` re-dispatch / half-atomic unblock (subsumed by exact-once ownership).
- starburstlabs#11 also proposes not pruning a stale worker while its supervisor's heartbeat is fresh. That's deliberately **not** included here. Exact-once ownership already makes the lock leak impossible, and the supervisor's heartbeat runs on a separate thread from its reap loop (`Process.waitpid2` + claim cleanup) — so a "fresh" supervisor can still have failed to reap a genuinely dead child, which would then shield that dead worker from heartbeat-based pruning and leave its jobs stuck. We prefer the airtight DB-level fix without that trade-off.

Credit to @mhenrixon (#689) and @tblais1224 & @briceburg-wb (starburstlabs#11). #689 can be closed in favor of this.
