### PR TITLE
Drop support for Ruby 3.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-        - 3.1
         - 3.2
         - 3.3
         - 3.4
@@ -34,12 +33,6 @@ jobs:
         database: [ mysql, postgres, sqlite ]
         gemfile: [ rails_7_1, rails_7_2, rails_8_0, rails_8_1, rails_main ]
         exclude:
-          - ruby-version: "3.1"
-            gemfile: rails_8_0
-          - ruby-version: "3.1"
-            gemfile: rails_8_1
-          - ruby-version: "3.1"
-            gemfile: rails_main
           - ruby-version: "3.2"
             gemfile: rails_main
     services:

--- a/Appraisals
+++ b/Appraisals
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 appraise "rails-7-1" do
-  # rdoc 6.14 is not compatible with Ruby 3.1
-  gem 'rdoc', '6.13'
   gem "railties", "~> 7.1.0"
 end
 
 appraise "rails-7-2" do
-  gem 'rdoc', '6.13'
   gem "railties", "~> 7.2.0"
 end
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Solid Queue is configured by default in new Rails 8 applications. If you're runn
 1. `bundle add solid_queue`
 2. `bin/rails solid_queue:install`
 
-(Note: The minimum supported version of Rails is 7.1 and Ruby is 3.1.6.)
+(Note: The minimum supported version of Rails is 7.1 and Ruby is 3.2.)
 
 This will configure Solid Queue as the production Active Job backend, create the configuration files `config/queue.yml` and `config/recurring.yml`, and create the `db/queue_schema.rb`. It'll also create a `bin/jobs` executable wrapper that you can use to start Solid Queue.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,4 +1,6 @@
 # Upgrading to version 1.5.x
+Ruby 3.1 is no longer supported, as it reached end-of-life in March 2025. Solid Queue now requires Ruby 3.2 or newer. If you're still on Ruby 3.1, Bundler will continue to resolve solid_queue 1.4.x for you, but you won't receive any new versions until you upgrade Ruby.
+
 Recurring schedules that don't specify a time zone are now interpreted in your application's configured time zone (`config.time_zone`) by default, instead of the system's local time. This only affects schedules without an explicit time zone (e.g. `every day at 9am`); schedules that already include one (e.g. `0 9 * * * America/New_York`) are unaffected.
 
 If your `config.time_zone` differs from the system time where your processes run, recurring jobs may fire at a different wall-clock time than before. To keep the previous behavior, set:

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rdoc", "6.13"
 gem "railties", "~> 7.1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rdoc", "6.13"
 gem "railties", "~> 7.2.0"
 
 gemspec path: "../"

--- a/solid_queue.gemspec
+++ b/solid_queue.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "README.md", "UPGRADING.md"]
   end
 
-  spec.required_ruby_version = '>= 3.1'
+  spec.required_ruby_version = '>= 3.2'
 
   rails_version = ">= 7.1"
   spec.add_dependency "activerecord", rails_version


### PR DESCRIPTION
Ruby 3.1 reached [end-of-life in March 2025](https://www.ruby-lang.org/en/downloads/branches/) and no longer receives security patches.

This PR:
- Raises `required_ruby_version` to `>= 3.2`
- Removes Ruby 3.1 from the CI matrix, along with the exclusions that existed only to keep 3.1 off Rails ≥ 8.0
- Unpins rdoc in the Rails 7.1 and 7.2 appraisals — it was held at 6.13 solely because rdoc 6.14 dropped Ruby 3.1 compatibility

No behavior changes. Apps still on Ruby 3.1 are unaffected: Bundler honors `required_ruby_version`, so they'll keep resolving solid_queue 1.4.x and simply won't receive newer versions.

This is the first step of a staged version-support update: Ruby 3.2 (EOL March 2026) and Rails < 8.0 will be dropped in Solid Queue 2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)