### PR TITLE
Add an update generator to copy new migrations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,4 @@ AllCops:
   TargetRubyVersion: 3.3
   Exclude:
     - "**/*_schema.rb"
+    - "lib/generators/solid_queue/update/templates/db/*"

--- a/app/models/solid_queue/record.rb
+++ b/app/models/solid_queue/record.rb
@@ -24,6 +24,16 @@ module SolidQueue
         end
       end
 
+      def warn_about_pending_migrations
+        SolidQueue.deprecator.warn(<<~DEPRECATION)
+          Solid Queue has pending database migrations. To get the new migration files, run:
+            rails solid_queue:update
+          And then:
+            rails db:migrate
+          These migrations will be required after version #{SolidQueue.next_major_version}.0
+        DEPRECATION
+      end
+
       # Pass index hints to the query optimizer using SQL comment hints.
       # Uses MySQL 8 optimizer hint query comments, which SQLite and
       # PostgreSQL ignore.

--- a/lib/generators/solid_queue/update/update_generator.rb
+++ b/lib/generators/solid_queue/update/update_generator.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails/generators/active_record"
+
+class SolidQueue::UpdateGenerator < Rails::Generators::Base
+  include ActiveRecord::Generators::Migration
+
+  source_root File.expand_path("templates", __dir__)
+
+  class_option :database, type: :string, aliases: %i[ --db ], default: "queue",
+    desc: "The database that Solid Queue uses. Defaults to `queue`"
+
+  def copy_new_migrations
+    Dir.glob(File.join(self.class.source_root, "db", "*.rb")).each do |migration_file|
+      name = File.basename(migration_file)
+      migration_template File.join("db", name), File.join(db_migrate_path, name), skip: true
+    end
+  end
+end

--- a/lib/solid_queue.rb
+++ b/lib/solid_queue.rb
@@ -86,6 +86,10 @@ module SolidQueue
     preserve_finished_jobs
   end
 
+  def deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new(next_major_version, "SolidQueue")
+  end
+
   def instrument(channel, **options, &block)
     ActiveSupport::Notifications.instrument("#{channel}.solid_queue", **options, &block)
   end

--- a/lib/solid_queue/engine.rb
+++ b/lib/solid_queue/engine.rb
@@ -43,5 +43,9 @@ module SolidQueue
         include ActiveJob::ConcurrencyControls
       end
     end
+
+    initializer "solid_queue.deprecator" do |app|
+      app.deprecators[:solid_queue] = SolidQueue.deprecator
+    end
   end
 end

--- a/lib/solid_queue/tasks.rb
+++ b/lib/solid_queue/tasks.rb
@@ -4,6 +4,11 @@ namespace :solid_queue do
     Rails::Command.invoke :generate, [ "solid_queue:install" ]
   end
 
+  desc "Copy any new Solid Queue migrations to the application"
+  task :update do
+    Rails::Command.invoke :generate, [ "solid_queue:update" ]
+  end
+
   desc "start solid_queue supervisor to dispatch and process jobs"
   task start: :environment do
     SolidQueue::Supervisor.start

--- a/lib/solid_queue/version.rb
+++ b/lib/solid_queue/version.rb
@@ -1,3 +1,7 @@
 module SolidQueue
   VERSION = "1.5.0"
+
+  def self.next_major_version
+    Gem::Version.new(VERSION).segments.first + 1
+  end
 end

--- a/test/unit/update_generator_test.rb
+++ b/test/unit/update_generator_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rails/generators/test_case"
+require "generators/solid_queue/update/update_generator"
+
+class UpdateGeneratorTest < Rails::Generators::TestCase
+  tests SolidQueue::UpdateGenerator
+  destination Rails.root.join("tmp/update_generator_test")
+  setup :prepare_destination
+
+  test "copies new migrations to the queue database migrations path" do
+    with_migration_template("add_batches_to_solid_queue") do
+      run_generator
+
+      assert_migration "db/queue_migrate/add_batches_to_solid_queue.rb" do |migration|
+        assert_match(/class AddBatchesToSolidQueue/, migration)
+      end
+    end
+  end
+
+  test "copies new migrations to another database's migrations path" do
+    with_migration_template("add_batches_to_solid_queue") do
+      run_generator %w[ --database primary ]
+
+      assert_migration "db/migrate/add_batches_to_solid_queue.rb"
+    end
+  end
+
+  test "skips migrations that have already been copied" do
+    with_migration_template("add_batches_to_solid_queue") do
+      run_generator
+      run_generator
+
+      assert_equal 1, Dir.glob(File.join(destination_root, "db/queue_migrate/*_add_batches_to_solid_queue.rb")).count
+    end
+  end
+
+  test "does nothing when there are no new migrations" do
+    run_generator
+
+    assert_empty Dir.glob(File.join(destination_root, "db/**/*.rb"))
+  end
+
+  private
+    def with_migration_template(name)
+      Dir.mktmpdir do |source_root|
+        FileUtils.mkdir_p File.join(source_root, "db")
+        File.write File.join(source_root, "db", "#{name}.rb"), <<~MIGRATION
+          class #{name.camelize} < ActiveRecord::Migration[7.1]
+            def change
+            end
+          end
+        MIGRATION
+
+        SolidQueue::UpdateGenerator.stubs(:source_root).returns(source_root)
+        yield
+      end
+    end
+end


### PR DESCRIPTION
Groundwork for shipping schema changes as regular migrations, starting with [batch support](https://github.com/rails/solid_queue/pull/142): new migrations will be **optional at first** (features degrade gracefully with a deprecation warning) and **required in the next major version**.

This adds:

- **`SolidQueue::UpdateGenerator`**: `bin/rails solid_queue:update` (or `bin/rails generate solid_queue:update`) copies any new migration files shipped with the gem into the application, honoring the Solid Queue database via `--database` (defaults to `queue`, so migrations land in the right `migrations_paths`). Idempotent: already-copied migrations are skipped. There are no migration templates yet — the first one arrives with batches.
- **`SolidQueue.deprecator`**, registered with the application's deprecators, so it follows the app's configured deprecation behavior.
- **`Record.warn_about_pending_migrations`**: the warning helper features guarded behind pending migrations will use, pointing users at `solid_queue:update` + `db:migrate` and noting the migrations become required after the next major version.

Extracted from earlier exploratory work (the `claimed-executions-by-process-name` branch) whose feature ended up not being needed — the migration machinery is what we want to keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)