### PR TITLE
Wait for the continuable job to start before interrupting it

### DIFF
--- a/test/dummy/app/jobs/continuable_job.rb
+++ b/test/dummy/app/jobs/continuable_job.rb
@@ -11,6 +11,7 @@ class ContinuableJob < ApplicationJob
 
   def perform(result, pause: 0)
     step :step_one do
+      result.update!(queue_name: queue_name, status: "started", value: "step_one")
       sleep pause if pause > 0
       result.update!(queue_name: queue_name, status: "stepped", value: "step_one")
     end

--- a/test/integration/continuation_test.rb
+++ b/test/integration/continuation_test.rb
@@ -32,7 +32,10 @@ class ContinuationTest < ActiveSupport::TestCase
   test "continuable job can be interrupted and resumed" do
     job = ContinuableJob.perform_later(@result, pause: 0.5.seconds)
 
-    sleep 0.2.seconds
+    # Wait for step_one to have started before signaling TERM, so the signal
+    # always arrives while the job is paused inside step_one and the interruption
+    # lands between the two steps
+    wait_while_with_timeout(3.seconds) { !JobResult.exists?(status: "started", value: "step_one") }
     signal_process(@pid, :TERM)
 
     wait_for_jobs_to_be_released_for(2.seconds)


### PR DESCRIPTION
Fixes the `ContinuationTest#test_continuable_job_can_be_interrupted_and_resumed` flake seen twice this week on mysql (on #764's and #765's CI runs), failing with `Expected: "stepped" / Actual: nil`.

CI log forensics (first-attempt logs + the `test.log` artifacts) showed TERM arriving **before any worker had claimed the job** — the fixed `sleep 0.2` wasn't enough on a loaded runner. `wait_for_jobs_to_be_released_for` then returned vacuously (zero claimed executions means it can't distinguish "released" from "never claimed"), and the assertions ran against an untouched `JobResult`. The artifact timeline even shows the job being claimed ~120ms *after* the failed assertion and then interrupting perfectly cleanly — the test just asserted too early. Reproduced locally 5/5 by shrinking the sleep, with the exact CI signature.

Same deterministic pattern as the other lifecycle fixes: the job now writes a `"started"` marker at the top of `step_one`, and the test waits for it before signaling, so TERM always lands while the job is paused inside step one. The 0.5s pause stays as-is deliberately — it must complete within the pool's shutdown timeout for the graceful between-steps interruption the test verifies.

Stability: 50 stress runs on mysql post-fix (only noise: one proven host-clock-jump from a laptop suspend), full file 10/10 green on rails_main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)