### PR TITLE
Roll back transactions leaked by killed job threads in tests

### DIFF
--- a/test/test_helpers/processes_test_helper.rb
+++ b/test/test_helpers/processes_test_helper.rb
@@ -75,8 +75,22 @@ module ProcessesTestHelper
   # rolling back the AUTOINCREMENT sequence bump too, so a later test's rows
   # get the same ids and the leaked thread overwrites them when it wakes up.
   # Kill the leaked threads instead, like a forked worker's exit would.
+  #
+  # A thread killed in the middle of a database write can skip the rollback in
+  # the transaction's ensure block and return its connection to the pool with
+  # the transaction still open. On SQLite that blocks every other writer until
+  # the pool reaper flushes the idle connection minutes later, so drop all
+  # connections to roll leaked transactions back. Transactional tests don't
+  # need this: they pin all threads to the test's own connection.
   def kill_running_jobs_in(worker)
-    worker&.pool&.send(:executor)&.kill
+    if pool = worker&.pool
+      pool.send(:executor).kill
+      pool.wait_for_termination(5)
+
+      unless self.class.use_transactional_tests
+        [ ActiveRecord::Base, SolidQueue::Record ].each { |base| base.connection_pool.disconnect! }
+      end
+    end
   end
 
   def wait_for_process_termination_with_timeout(pid, timeout: 10, exitstatus: 0, signaled: nil)


### PR DESCRIPTION
Since #766, tests that stop in-process workers kill the job threads those workers leak. That kill can interrupt a thread in the middle of a database write, skipping the rollback in the transaction's ensure block while still returning the connection to the pool — with the write transaction still open.

On SQLite that open transaction locks out every other writer. Nothing clears it until the connection pool's reaper flushes the idle connection at its default 300-second `idle_timeout`, so a single unlucky kill turns into a ~5-minute cascade of `SQLite3::BusyException: database is locked` errors through whatever tests run next, after which the suite mysteriously heals.

That's been the signature of the recent flaky sqlite legs on CI: dozens of errors, always starting with `SolidQueue::JobTest#test_try_to_discard_claimed_job` failing in its own teardown ~10 seconds after killing a job thread (it's the only non-transactional caller of the helper), always healing ~300 seconds later. For example, [this run](https://github.com/rails/solid_queue/actions/runs/30287837861) and [this one](https://github.com/rails/solid_queue/actions/runs/30287759413), both on main.

The fix: after killing the threads, wait for them to die, then drop all pool connections, which rolls back anything they left open. Transactional tests don't need it — they pin every thread to the test's own connection, so a killed thread can't strand a lock on a connection of its own.

The leaked state and the fix are easy to see in isolation: a thread killed while holding an open transaction leaves the pool with `raw_connection.transaction_active? == true` and the next writer times out; after `disconnect!`, the write goes through instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)