### PR TITLE
Reschedule dynamic recurring tasks when they are updated

### DIFF
--- a/lib/solid_queue/scheduler/recurring_schedule.rb
+++ b/lib/solid_queue/scheduler/recurring_schedule.rb
@@ -48,8 +48,10 @@ module SolidQueue
 
     def reschedule_dynamic_tasks
       wrap_in_app_executor do
+        previous_tasks = dynamic_tasks.index_by(&:key)
         reload_dynamic_tasks
         schedule_created_dynamic_tasks
+        reschedule_updated_dynamic_tasks(previous_tasks)
         unschedule_deleted_dynamic_tasks
       end
     end
@@ -71,6 +73,16 @@ module SolidQueue
 
       def schedule_created_dynamic_tasks
         RecurringTask.dynamic.where.not(key: scheduled_tasks.keys).each do |task|
+          schedule_task(task)
+        end
+      end
+
+      def reschedule_updated_dynamic_tasks(previous_tasks)
+        dynamic_tasks.each do |task|
+          previous_task = previous_tasks[task.key]
+          next if previous_task.nil? || previous_task.updated_at == task.updated_at
+
+          scheduled_tasks[task.key]&.cancel
           schedule_task(task)
         end
       end

--- a/test/unit/scheduler_test.rb
+++ b/test/unit/scheduler_test.rb
@@ -131,6 +131,26 @@ class SchedulerTest < ActiveSupport::TestCase
     scheduler&.stop
   end
 
+  test "picks up updates to dynamic tasks post-start" do
+    task = SolidQueue::RecurringTask.create!(
+      key: "updatable_task", static: false, class_name: "AddToBufferJob", schedule: "every hour", arguments: [ 42 ]
+    )
+
+    scheduler = SolidQueue::Scheduler.new(recurring_tasks: {}, dynamic_tasks_enabled: true, polling_interval: 0.1).tap(&:start)
+
+    wait_for_registered_processes(1, timeout: 1.second)
+
+    task.update!(schedule: "every second")
+
+    wait_while_with_timeout(3.seconds) { SolidQueue::Job.count < 1 }
+
+    skip_active_record_query_cache do
+      assert SolidQueue::Job.count >= 1, "Expected the updated schedule to enqueue jobs without a scheduler restart"
+    end
+  ensure
+    scheduler&.stop
+  end
+
   test "updates metadata after removing dynamic task post-start" do
     old_dynamic_task = SolidQueue::RecurringTask.create!(
       key: "old_dynamic_task",


### PR DESCRIPTION
Fixes #738

### Problem

When dynamic recurring tasks are enabled, the scheduler's polling cycle (`Scheduler::RecurringSchedule#reschedule_dynamic_tasks`) only handles two cases:

- `schedule_created_dynamic_tasks` — rows whose key isn't scheduled yet
- `unschedule_deleted_dynamic_tasks` — scheduled entries whose key is no longer in the DB

A task whose key exists in both places falls through both checks, so any update to its `schedule`, `class_name`, `arguments`, `queue_name`, etc. is silently ignored: the scheduler keeps firing against the pre-update definition until the process restarts.

```ruby
task = SolidQueue.schedule_recurring_task("import", class: "ImportJob", schedule: "0 4 * * *")
# scheduler picks it up on the next poll

task.update!(schedule: "0 8 * * *")
# expected: fires at 08:00 from now on
# actual:   keeps firing at 04:00 until the scheduler restarts
```

### Fix

Keep the previously loaded snapshot of dynamic tasks across each polling cycle and compare every reloaded task's `updated_at` against it. Any task that changed gets its in-memory scheduled entry cancelled and rescheduled from the fresh record, mirroring what a delete + create with a polling cycle in between would have done.

### Testing

Added a regression test that starts a scheduler with a dynamic task on an hourly cadence, updates it to `every second` while the scheduler is running, and asserts jobs get enqueued without a restart. The test fails on `main` and passes with this change.
