### PR TITLE
Document how to update dynamic recurring tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,6 +830,8 @@ SolidQueue.unschedule_recurring_task("my_dynamic_task")
 
 Only dynamic tasks can be unscheduled at runtime. Attempting to unschedule a static task (defined in `config/recurring.yml`) will raise an `ActiveRecord::RecordNotFound` error.
 
+To update an existing dynamic task, unschedule it and then schedule it again with the new options. A running scheduler only detects dynamic tasks being created and deleted, so updating a `SolidQueue::RecurringTask` record in place (for example, changing its `schedule` with `update!`) won't be picked up until the scheduler restarts.
+
 Tasks scheduled like this persist between Solid Queue's restarts and won't stop running until you manually unschedule them. 
 
 ## Inspiration


### PR DESCRIPTION
Follow-up to #774 and #739, related to #738.

Updating a dynamic recurring task in place (e.g. `task.update!(schedule: ...)`) isn't picked up by a running scheduler — by design, the way to update a task is to unschedule it and schedule it again, as @rosa explained in https://github.com/rails/solid_queue/pull/739#issuecomment-5022493765.

Since this wasn't stated in the README's dynamic tasks section and has now come up a few times (#738 plus two PRs attempting the same fix), this adds a short paragraph spelling it out.
